### PR TITLE
Contact page: hide phone number when 'gameplay' is false

### DIFF
--- a/client/components/imports/ice-contact.jsx
+++ b/client/components/imports/ice-contact.jsx
@@ -1,23 +1,28 @@
 import React, {PropTypes} from 'react';
 import { Grid, Button, Header } from 'semantic-ui-react';
+import GamestateComp from './GamestateComp';
 
-const { phone } = Meteor.settings.public.contact;
-
-export default class ICEContact extends React.Component {
+class ICEContact extends React.Component {
   render() {
+    const gamestate = this.props.gamestate || {};
+    const { gameplay } = gamestate;
+    const phone = gameplay ? Meteor.settings.public.contact.phone :
+      "(Hidden)"
+
     return (
       <Grid>
         <Grid.Row columns='1'>
           <Grid.Column>
-            <Header as='h2' content='In Game Contact' subheader='(For emergency or reporting unsportsmanlike behavior)'/>
+            <Header as='h2' content='In Game Contact'
+                    subheader='For emergency or reporting unsportsmanlike behavior. Phone available only when Hunt in session'/>
           </Grid.Column>
         </Grid.Row>
         <Grid.Row columns='3'>
           <Grid.Column>
-            <Button fluid as='a' color='blue' content={'Call: ' + phone} href={"tel:" + phone} />
+            <Button disabled={!gameplay} fluid as='a' color='blue' content={'Call: ' + phone} href={"tel:" + phone} />
           </Grid.Column>
           <Grid.Column>
-            <Button fluid as='a' color='orange' content={'Text: ' + phone} href={"sms:" + phone} />
+            <Button disabled={!gameplay} fluid as='a' color='orange' content={'Text: ' + phone} href={"sms:" + phone} />
           </Grid.Column>
           <Grid.Column>
             <Button fluid as='a' color='green' content='Email' href="mailto:support@greatpuzzlehunt.com"/>
@@ -27,3 +32,6 @@ export default class ICEContact extends React.Component {
     );
   }
 }
+
+ICEContact = GamestateComp(ICEContact);
+export default ICEContact;


### PR DESCRIPTION
We forgot to take down the phone number and it is getting spam calls. To reduce the amount of crawlers that find it and add it to their call lists, this PR hides the phone numbers unless the game is in progress (ie `gameplay = true`).