### PR TITLE
Hotfix: bcrypt symbol lookup error

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0-beta.55",
     "babel-runtime": "^6.18.0",
-    "bcrypt": "3.0.6",
+    "bcrypt": "^0.8.7",
     "body-parser": "^1.15.2",
     "clipboard": "^1.6.1",
     "jszip": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
   "devDependencies": {
     "autoprefixer": "^6.3.1"
   },
+  "engines": {
+    "node": "8.12.x"
+  },
   "postcss": {
     "plugins": {
       "autoprefixer": {


### PR DESCRIPTION
Updating to `bcrypt@3` caused the app to crash with the following error:

`.meteor/heroku_build/bin/node: symbol lookup error: /app/.meteor/heroku_build/app/programs/server/npm/node_modules/bcrypt/lib/binding/bcrypt_lib.node: undefined symbol: ...`

See a discussion of the problem here: https://github.com/kelektiv/node.bcrypt.js/issues/656

An apparent fix is to update to node 8.12 so that the N-API bindings are compatible between bcrypt and node. However, this does not seem to work in all cases when deploying to Heroku.

Because we are not taking advantage of any new bcrypt features and because no security updates have apparently been made to the library, I am simply rolling back the bcrypt version to what we had before the recent `/tickets` API update.