### PR TITLE
Use SyncedCron to send nightly reports

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -40,3 +40,4 @@ cfs:filesystem
 percolate:migrations
 dynamic-import@0.3.0
 cfs:gridfs
+littledata:synced-cron

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -62,6 +62,7 @@ jquery@1.11.11
 juliancwirko:postcss@1.2.0
 launch-screen@1.1.1
 less@2.7.12
+littledata:synced-cron@1.5.1
 livedata@1.0.18
 localstorage@1.2.0
 logging@1.1.19

--- a/server/imports/autoSendReports.js
+++ b/server/imports/autoSendReports.js
@@ -3,36 +3,26 @@ import moment from 'moment';
 
 import { sendReports } from '../../lib/imports/sendReports';
 
-const CHECK_INTERVAL = {
-  minutes: 5,
-};
+SyncedCron.add({
+  name: 'Nightly gear reports',
+  schedule: function(parser) {
+    // We're using UTC, so 8:15 = 12:15am PT
+    return parser.text('at 08:15am');
+  },
+  job: function() {
+    const gameState = Gamestate.findOne();
+    const sendTime = moment();
+    if(!gameState.doSendNightlyReports){
+      return;
+    }
 
-function autoSendReports() {
-  const now = moment();
-  const gameState = Gamestate.findOne();
-  if(!gameState.doSendNightlyReports){
-    return;
-  }
-  const lastAutoReportSend = moment(gameState.lastAutoReportSend || moment(now).subtract(2, 'day'));
-  const waitingUntil = moment(lastAutoReportSend).add(1, 'day');
-
-  Meteor.logger.info(`Checking to send auto reports. now: ${now} .. waiting for ${waitingUntil}`);
-
-  if (gameState.sendReportsTo.length <= 0) {
-    Meteor.logger.info("Skipping admin reports because \"gameState.sendReportsTo\" is empty!");
-    return;
-  }
-
-  if (now.isAfter(waitingUntil)) {
-    const sendTime = moment(now).startOf('hour');
     Meteor.logger.info(`Sending auto reports at ${sendTime} to: ${gameState.sendReportsTo}`);
     sendReports(gameState.sendReportsTo);
     Gamestate.update({ _id: gameState._id}, { $set: { lastAutoReportSend: sendTime }});
   }
-}
-
-Meteor.startup(() => {
-  // On Startup, init Interval for puzzle timeout watcher.
-  const interval = moment.duration(CHECK_INTERVAL).asMilliseconds();
-  Meteor.setInterval(autoSendReports, interval);
 });
+
+SyncedCron.config({
+  utc: true,
+});
+SyncedCron.start();


### PR DESCRIPTION
The old home-made method for sending nightly reports had the shortcoming that it was not possible to select a specific time for reports to be sent. By using the `later` library (wrapped by the meteor `SyncedCron` package), we can specify a specific time for reports and have them run regularly. This package could also be helpful for future tasks should we need it.