### PR TITLE
/tickets API: fix gear order dates

### DIFF
--- a/server/imports/processTransaction.js
+++ b/server/imports/processTransaction.js
@@ -104,6 +104,7 @@ function makeCode(type) {
 };
 
 function createGearOrders(tx, email, gearOrders) {
+  const now = new Date();
   gearOrders.forEach((gearOrder) => {
     const { itemcode, color, logo_color: logoColor, size, qty, amount } = gearOrder;
     GearOrders.insert({
@@ -115,8 +116,8 @@ function createGearOrders(tx, email, gearOrders) {
       size,
       qty: parseInt(qty),
       amount: parseFloat(amount),
-      createdAt: new Date(gearOrder.created_at),
-      updatedAt: new Date(gearOrder.updated_at),
+      createdAt: now,
+      updatedAt: now,
     });
   });
 }


### PR DESCRIPTION
The CashNet requests no longer appear to include the
'created_at' or 'updated_at' fields. Thus when we tried to
parse those (undefined) values into dates, we got back dates
corresponding with the Unix epoch (1/1/1970). This lead to
all entries on the 'gear orders' spreadsheet - and indeed the
corresponding values in the database - being inaccurate.

Because this field no longer exists, we simply take the
current server time to be the default value for these fields.