### PR TITLE
Registration page: don't attempt to use browser's location

### DIFF
--- a/client/components/register/imports/RegisterForm.jsx
+++ b/client/components/register/imports/RegisterForm.jsx
@@ -127,12 +127,6 @@ class RegisterForm extends Component {
       holdHarmless: false,
       showHoldHarmless: false,
     };
-
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition((loc) => {
-        this.setState({ coords: { longitude: loc.coords.longitude, latitude: loc.coords.latitude } });
-      });
-    }
   }
 
   render() {


### PR DESCRIPTION
Personally, I'm tired of the browser asking for my location when I go to the register page. I think Millie is too. I don't think it adds enough value to keep.