### PR TITLE
auto reports: respect DST; clean up logs

### DIFF
--- a/server/imports/autoSendReports.js
+++ b/server/imports/autoSendReports.js
@@ -6,12 +6,13 @@ import { sendReports } from '../../lib/imports/sendReports';
 SyncedCron.add({
   name: 'Nightly gear reports',
   schedule: function(parser) {
-    // We're using UTC, so 8:15 = 12:15am PT
-    return parser.text('at 08:15am');
+    // We need to convert to UTC and account for Daylight Savings
+    const time = moment().isDST() ? "at 7:15am" : "at 8:15am";
+    return parser.text(time);
   },
   job: function() {
     const gameState = Gamestate.findOne();
-    const sendTime = moment();
+    const sendTime = moment().toString();
     if(!gameState.doSendNightlyReports){
       return;
     }


### PR DESCRIPTION
* We set the nightly reports in UTC, but this does not change when
  Daylight savings time starts. Thus we check for DST and then set
  the report time accordingly.
  This has not been super thoroughly tested, so we may run into some
  odd issues or corner cases next year when we turn reports back on.
* Previously, the 'lastAutoReportSend' object logged in the database
  was an entire moment() object, which made the DB record super messy
  and ugly. We clean it up to just be a simple string.

**NOTE** that this should not be merged until #43 is merged, as this is built on top of that branch.