### PR TITLE
Virtual checkin and gameplay improvements

### DIFF
--- a/client/components/TeamCheckin/imports/TeamMemberCheckIn.jsx
+++ b/client/components/TeamCheckin/imports/TeamMemberCheckIn.jsx
@@ -6,6 +6,8 @@ import {
   Segment, Header, Grid, Icon, Button, Message, List
 } from 'semantic-ui-react';
 
+import CheckInPacket from '../../game/imports/CheckInPacket'; // virtualeventonly
+
 class TeamMemeberCheckIn extends Component {
   render() {
     return (
@@ -19,27 +21,35 @@ class TeamMemeberCheckIn extends Component {
     );
   }
 
-  _checkinConfirmation() {
-    const { checkinConfirmed: confirmed } = this.props.team;
-    const header = confirmed ? "Team Check In Confirmed!" : "Awaiting Check In Confirmation";
-    let content = <Link to="/game"><Button size="small" color="purple" icon="puzzle" content="Go To Game" style={{ marginTop: '10px' }} /></Link>;
-    if (!confirmed) {
-      content = (
+  _unconfirmed(){
+    return (
+      <Message size="large" info>
+        <Message.Header>Awaiting Check In Confirmation</Message.Header>
         <List bulleted>
           <List.Item>Check in your players below.</List.Item>
           <List.Item>Then check in your team with the button at the bottom!</List.Item>
         </List>
-      );
-    }
+      </Message>
+    )
+  }
 
+  _confirmed(){
     return (
-      <Message
-        size="large"
-        positive={confirmed}
-        info={!confirmed}
-        header={header}
-        content={content}/>
-    );
+      <Message size="large" positive>
+        <Message.Header>Team Check In Confirmed!</Message.Header>
+        <CheckInPacket />
+        <Link to="/game">
+          <Button fluid color="purple" icon="puzzle"
+            content="Go To Game" style={{ marginTop: '10px' }} />
+        </Link>
+      </Message>
+    )
+  }
+
+  _checkinConfirmation() {
+    const { checkinConfirmed: confirmed } = this.props.team;
+
+    return confirmed ? this._confirmed() : this._unconfirmed();
   }
 
   _renderMembers() {

--- a/client/components/admin/AdminPuzzles/imports/CheckinPacketEditor.jsx
+++ b/client/components/admin/AdminPuzzles/imports/CheckinPacketEditor.jsx
@@ -8,14 +8,14 @@ class Editor extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            loading: true,
+            loading: false,
+            url: "",
         };
     }
     componentWillReceiveProps(props) {
         if (props.gamestate) {
             this.setState({
                 url: props.gamestate.checkinPacketURL || "",
-                loading: false,
             });
         }
     }

--- a/client/components/game/imports/CheckInPacket.jsx
+++ b/client/components/game/imports/CheckInPacket.jsx
@@ -6,7 +6,6 @@ import GamestateComp from '../../imports/GamestateComp';
 
 class CheckinPacketUI extends Component {
     render() {
-        console.log(this.props);
         if (!this.props.ready){
             return <span>Check-in Packet loading...</span>;
         }

--- a/client/components/game/imports/PuzzleHints.jsx
+++ b/client/components/game/imports/PuzzleHints.jsx
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import React, { PropTypes } from 'react';
-import { Segment, Grid, Header, Button, Image, Message, Confirm } from 'semantic-ui-react';
+import { Segment, Grid, Header, Button, Image, Message, Confirm, Icon } from 'semantic-ui-react';
 import { getHintsTaken } from '../../../../lib/imports/puzzle-helpers';
 
 const HINT_COST = [5, 10, 15];
@@ -25,16 +25,27 @@ export default class PuzzleHints extends React.Component {
     const { showConfirm, hintToTake } = this.state;
     const currentHintCost = HINT_COST[getHintsTaken(puzzle)];
 
+    const confirmContent = (
+      <Segment basic style={{fontSize: '16px'}}>
+        <p>Do you want to take <b>Hint {hintToTake + 1}</b>?</p>
+        <p>This will add <b>{currentHintCost} minutes</b> to your team's score!</p>
+      </Segment>
+    );
+    const confirmButton = (
+      <Button color="blue">
+        <Icon name="clock" /> YES! Take the hint!
+        </Button>
+    );
     return (
       <Grid style={ this.gridStyle }>
         { this._renderHints() }
 
         <Confirm
           open={showConfirm}
-          header="Are you sure?"
-          content={<Segment basic style={{fontSize: '16px'}}><p>Do you want to take <b>Hint {hintToTake + 1}</b>?</p><p>Cost: <b>{currentHintCost} minutes</b></p></Segment>}
-          confirmButton={`Take the Hint!`}
-          cancelButton="Nevermind"
+          header="Wait! Are you sure?"
+          content={confirmContent}
+          confirmButton={confirmButton}
+          cancelButton="No, not yet"
           onCancel={() => this.setState({showConfirm: false, hintToTake: null })}
           onConfirm={() => this._takeHint()}
           size="large"

--- a/client/components/game/imports/UnstartedPuzzleVirtual.jsx
+++ b/client/components/game/imports/UnstartedPuzzleVirtual.jsx
@@ -1,5 +1,5 @@
 import React, {PropTypes} from 'react';
-import { Segment, Header, Button, Confirm, Modal } from 'semantic-ui-react';
+import { Segment, Header, Button, Modal, Icon, } from 'semantic-ui-react';
 
 export default class UnstartedPuzzleVirtual extends React.Component {
   constructor(props) {
@@ -62,14 +62,32 @@ export default class UnstartedPuzzleVirtual extends React.Component {
 
         { this._downloadButton() }
 
-        <Confirm open={confirmOpen}
-          onCancel={this.handleCancelConfirm}
-          onConfirm={this.handleConfirm}
-          header={`Are you sure you're ready to start the puzzle "${puzzleName}"?`}
-          content="You will be presented with a download link (PDF) and the timer will start immediately. Make sure your whole team is ready to go!"
-          confirmButton="YES, we're ready!"
-          cancelButton="Not yet"
-        />
+        <Modal open={confirmOpen} onClose={this.handleCancelConfirm}>
+          <Header color="red">
+            <Icon name="warning" />
+            <Header.Content>
+              <strong>Are you sure you're ready to start the puzzle "{puzzleName}"?</strong>
+            </Header.Content>
+          </Header>
+          <Modal.Content>
+            If you click Yes,
+            <ul>
+              <li>The timer will start</li>
+              <li>You will be able to download the puzzle (PDF)</li>
+            </ul>
+            <Segment textAlign="center">
+              <strong>Make sure your whole team is ready!</strong>
+            </Segment>
+          </Modal.Content>
+          <Modal.Actions>
+            <Button onClick={() => this.handleCancelConfirm()}>
+              Not yet...
+            </Button>
+            <Button color="blue" onClick={() => this.handleConfirm()}>
+              <Icon name="clock" /> YES! Start the timer!
+            </Button>
+          </Modal.Actions>
+        </Modal>
 
       </Segment>
     );


### PR DESCRIPTION
Make warnings before starting puzzles and taking hints stronger.

Add a link to download the checkin packet on the checkin page.

Misc cleanup.

![checkin-page](https://user-images.githubusercontent.com/12406521/112771584-2032f480-8ff2-11eb-9d6e-046c9f976f17.PNG)
![hint-warning-0](https://user-images.githubusercontent.com/12406521/112771586-20cb8b00-8ff2-11eb-97e8-aa818b558645.PNG)
![start-puzzle-warning-1](https://user-images.githubusercontent.com/12406521/112771589-23c67b80-8ff2-11eb-993c-1318e85e3950.PNG)
