### PR TITLE
Add banner and config for Zoom Webinar URL

### DIFF
--- a/client/components/admin/AdminGamestate/imports/GamestateControls.jsx
+++ b/client/components/admin/AdminGamestate/imports/GamestateControls.jsx
@@ -11,6 +11,8 @@ class GamestateControlsInner extends Component {
     this.state = {
       reportDLBusy: false,
       reportEmail: "",
+      webinarURL: "",
+      webinarID: "",
     };
     this._getReport = this._getReport.bind(this);
   }
@@ -20,6 +22,8 @@ class GamestateControlsInner extends Component {
       this.setState({
         registration: props.gamestate.registration,
         gameplay: props.gamestate.gameplay,
+        webinarURL: props.gamestate.webinarURL || "",
+        webinarID: props.gamestate.webinarID || "",
       });
     }
   }
@@ -105,6 +109,29 @@ class GamestateControlsInner extends Component {
         { this._fieldButton('Registration') }
         { this._fieldButton('buyGear', '"Buy Gear" Button (on homepage)') }
 
+        <Header as='h3' content='Webinar'/>
+        <Input
+            placeholder="https://zoom.us/"
+            name="webinarURL"
+            size="small"
+            label="URL"
+            value={this.state.webinarURL}
+            onChange={this.handleChange}
+            />
+        <Input
+            placeholder="123 456 789"
+            name="webinarID"
+            size="small"
+            label="ID"
+            value={this.state.webinarID}
+            onChange={this.handleChange}
+            />
+
+          <Button
+            content="Update Zoom Info"
+            onClick={() => this.setWebinarInfo(this.state.webinarURL, this.state.webinarID)} />
+        { this._fieldButton('showWebinarLink', 'Zoom Webinar link banner')}
+
         <Header as='h3' content='Game Day!'/>
         { this._fieldButton('CheckIn') }
         { this._fieldButton('Gameplay') }
@@ -145,6 +172,15 @@ class GamestateControlsInner extends Component {
       }
     });
   };
+
+  setWebinarInfo(url, id){
+    Meteor.call('admin.gamestate.setWebinarInfo', url, id, error => {
+      if(error){
+        console.log(error);
+        alert("Failed to set webinar info. " + error.reason);
+      }
+    });
+  }
 
   _fieldButton(fieldName, displayName) {
     if(!displayName){

--- a/client/components/imports/ice-contact.jsx
+++ b/client/components/imports/ice-contact.jsx
@@ -1,5 +1,5 @@
 import React, {PropTypes} from 'react';
-import { Grid, Button, Header } from 'semantic-ui-react';
+import { Grid, Button, Header, List } from 'semantic-ui-react';
 import GamestateComp from './GamestateComp';
 
 class ICEContact extends React.Component {
@@ -8,16 +8,29 @@ class ICEContact extends React.Component {
     const { gameplay } = gamestate;
     const phone = gameplay ? Meteor.settings.public.contact.phone :
       "(Hidden)"
+    let { webinarURL, webinarID } = gamestate;
+    if (!webinarID) webinarID = "Coming soon...";
+
+    let joinByLink = "Meeting details will be posted soon";
+    if (webinarURL) {
+      joinByLink = (
+            <Header as='h3'>
+              <strong>Click to join the webinar:</strong> <a href={webinarURL} target="_blank">{webinarURL}</a>
+            </Header>
+      );
+    }
 
     return (
       
       <Grid>
+
         <Grid.Row columns='1'>
           <Grid.Column>
             <Header as='h2' content='In Game Contact'
-                    subheader='For emergency or reporting unsportsmanlike behavior. Phone available only when Hunt in session'/>
+                    subheader='For emergency or reporting unsportsmanlike behavior. Phone available only when Hunt in session; standard fees may apply'/>
           </Grid.Column>
         </Grid.Row>
+
         <Grid.Row columns='3'>
           <Grid.Column>
             <Button disabled={!gameplay} fluid as='a' color='blue' content={'Call: ' + phone} href={"tel:" + phone} />
@@ -27,6 +40,39 @@ class ICEContact extends React.Component {
           </Grid.Column>
           <Grid.Column>
             <Button fluid as='a' color='green' content='Email' href="mailto:support@greatpuzzlehunt.com"/>
+          </Grid.Column>
+        </Grid.Row>
+
+        <Grid.Row columns='1'>
+          <Grid.Column>
+            <Header as='h2' content='Zoom Webinar' />
+            Join us before and after the Hunt for announcements and information.
+            Stream starts at <strong>10:15 am (PST)</strong> on the day of the Hunt.
+
+            {joinByLink}
+            <List>
+              <List.Item>
+                <strong>Or One tap mobile:</strong>
+                <List>
+                  <List.Item>
+                    <em>US:</em> +13017158592,,93972548433#  or +13126266799,,93972548433#
+                  </List.Item>
+                </List>
+              </List.Item>
+              <List.Content>
+                <strong>Or Telephone:</strong><br />
+                Dial (for higher quality, dial a number based on your current location):
+                <List.List>
+                  <List.Item>
+                    <em>US:</em> +1 301 715 8592  or +1 312 626 6799  or +1 646 558 8656  or +1 253 215 8782  or +1 346 248 7799  or +1 669 900 6833 
+                  </List.Item>
+                </List.List>
+                <a href="https://wwu-edu.zoom.us/u/abnvpc64Kw" target="_blank">
+                  Click here for a list of all international numbers available
+                </a><br />
+                <strong>Webinar ID:</strong> {webinarID}<br />
+              </List.Content>
+            </List>
           </Grid.Column>
         </Grid.Row>
       </Grid>

--- a/client/components/public/Contact.jsx
+++ b/client/components/public/Contact.jsx
@@ -19,7 +19,6 @@ Contact = class Contact extends Component {
         <br/><br/>
         For Account/Tech Questions Contact <a href='mailto:support@greatpuzzlehunt.com'>support@greatpuzzlehunt.com</a>
       </h3>
-      <HomePeople />
       <ProfileCards />
 
       </Segment>

--- a/client/components/topbar/TopBar.jsx
+++ b/client/components/topbar/TopBar.jsx
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import React, { Component } from 'react';
 import { Link, browserHistory } from 'react-router';
 import { withTracker } from 'meteor/react-meteor-data';
-import { Icon } from 'semantic-ui-react';
+import { Icon, Segment, Container } from 'semantic-ui-react';
 import Scrollchor from 'react-scrollchor';
 
 import GamestateComp from '../imports/GamestateComp';
@@ -119,6 +119,33 @@ TopBar = class TopBar extends Component {
     return window.innerWidth < 1100; 
   }
   render() {
+    return (
+      <div>
+        {this._renderTopBar()}
+        {this._renderBanner()}
+      </div>
+    );
+  }
+
+  _renderBanner() {
+    const { gamestate } = this.props;
+    if (!gamestate || !gamestate.showWebinarLink) return "";
+
+    const { webinarURL } = gamestate
+
+    return (
+      <Container>
+        <Segment textAlign="center" color="blue" inverted>
+          <a href={webinarURL} target="_blank" style={{color: "white"}}>
+            <Icon name="video camera" />
+            Click here to join the Zoom Webinar
+          </a>
+        </Segment>
+      </Container>
+    )
+  }
+
+  _renderTopBar() {
     const { isAdmin, isVolunteer } = this.props;
 
     let logoDesktop = {

--- a/lib/collections/gamestate-collection.js
+++ b/lib/collections/gamestate-collection.js
@@ -80,6 +80,25 @@ Meteor.methods({
     Meteor.logger.info(`${user.name} removed ${email} from list of nightly report recipients`);
   },
 
+  'admin.gamestate.setWebinarInfo'(url, id) {
+    requireAdmin();
+    if (!Meteor.isServer) return true;
+    check(url, String);
+    check(id, String);
+
+    const user = Meteor.users.findOne(this.userId);
+    const currentState = Gamestate.findOne({});
+
+    Gamestate.update({ _id: currentState._id }, {
+      $set: {
+        webinarURL: url,
+        webinarID: id
+      }
+    });
+
+    Meteor.logger.info(`${user.name} updated the webinar info`);
+  },
+
   'admin.gamestate.setCheckinPacket'(url) {
     requireAdmin();
     if (!Meteor.isServer) return true;


### PR DESCRIPTION
Add a prominent banner on, well, EVERY page underneath the "top bar" to display a Zoom webinar URL. Also add controls in the admin page to enable/disable this header and set the URL for the Zoom link.

Affected areas:
* Top bar, displayed on every page
* Admin page - add ability to enable/disable the banner
  * This all should work even if the fields are not present in the `gamestate` collection, theoretically.

When testing, please try:
* In admin page, BEFORE setting a URL (so this field is undefined in `gamestate`), enable the banner. Then make sure the top bar isn't too broken, and there are no errors in the web console when rendering the page.
* Maybe put in a real Zoom link to make sure it opens?
* Anything else you can think of...