### PR TITLE
Remove extra debug log call

### DIFF
--- a/server/publications/teams.js
+++ b/server/publications/teams.js
@@ -45,10 +45,7 @@ Meteor.publish('teams.myTeam', function() {
    * removed at a later date if needed.
    */
   if( user.teamId ){
-    Meteor.logger.debug("[teams.myTeam] User has a team; query for members");
     ret.push(Meteor.users.find({ teamId: user.teamId }, { fields: userFields }));
-  } else {
-    Meteor.logger.info("[teams.myTeam] User has no team; do not query for members");
   }
 
   return ret


### PR DESCRIPTION
The "server and database mismatch" error is pretty decisively fixed
at this point, so no reason to continue gumming up the logs with this
message any more.