### PR TITLE
Users: add 'inPersonAllowed' functionality

### DIFF
--- a/client/components/admin/AdminUsers/imports/AdminUserEditForm.jsx
+++ b/client/components/admin/AdminUsers/imports/AdminUserEditForm.jsx
@@ -24,7 +24,7 @@ const USER_FIELDS = [
   '_id', 'firstname', 'lastname', 'email', 'accountType',
   'phone', 'age', 'address', 'city', 'zip', 'state', 'country', 'ecName',
   'ecRelationship', 'ecPhone', 'ecEmail', 'parentGuardian',
-  'photoPermission',
+  'photoPermission', "inPersonAllowed",
 ];
 
 class AdminUserEditForm extends Component {
@@ -34,7 +34,7 @@ class AdminUserEditForm extends Component {
   }
 
   _stateFromProps(props) {
-    return _.pick(props.user, USER_FIELDS);
+    return _.pick(props.user, [...USER_FIELDS, "paid"]);
   }
 
   componentWillReceiveProps(props) {
@@ -42,7 +42,7 @@ class AdminUserEditForm extends Component {
   }
 
   render() {
-    const user = _.pick(this.state, USER_FIELDS);
+    const user = _.pick(this.state, [...USER_FIELDS, "paid"]);
     return (
       <Form onSubmit={(e) => this._update(e)}>
 
@@ -93,6 +93,14 @@ class AdminUserEditForm extends Component {
           defaultChecked={user.photoPermission}
           name='photoPermission'
           label="User photo/video permission"
+          onChange={(e, data) => this._handleDataChange(e, data)} />
+
+        <Form.Checkbox
+          toggle
+          defaultChecked={user.inPersonAllowed}
+          name='inPersonAllowed'
+          label="In-person gameplay allowed"
+          disabled={!user.paid}
           onChange={(e, data) => this._handleDataChange(e, data)} />
 
         <Header as='h3' icon={<Icon name='ambulance' color='red' />}

--- a/client/components/profile/ProfileEditor.jsx
+++ b/client/components/profile/ProfileEditor.jsx
@@ -23,8 +23,44 @@ ProfileEditor = class ProfileEditor extends Component {
       lastname: user.lastname || '',
       email: user.getEmail(),
       lookingForTeam: user.lookingForTeam || false,
+      inPersonAllowed: user.inPersonAllowed,
       bio: user.bio || '',
     };
+  }
+
+  _gameTypeBox() {
+    let icon, header, content;
+    const footer = (
+      <span>For questions, see our <Link to="/contact">Contact Page</Link> or
+      our <Link to="/faq">FAQ</Link>.</span>
+    );
+
+    if (!this.state.inPersonAllowed) {
+      icon = "video camera";
+      header = "You are registered to play virtually";
+      content = (
+        <span>
+          Only WWU community members with in-person ticket codes are allowed to
+          participate in person for 2022. {footer}
+        </span>
+      );
+    } else {
+      icon = "group";
+      header = "You may play in person this year!";
+      content = (
+        <span>
+          You have purchased an in-person ticket code. If your team has the
+          "in person" setting enabled, please join us on Red Square for the
+          event. {footer}
+        </span>
+      );
+    }
+    return (
+      <Message
+        icon={icon}
+        header={header}
+        content={content} />
+    )
   }
 
   render() {
@@ -33,6 +69,9 @@ ProfileEditor = class ProfileEditor extends Component {
     <Segment basic>
       <Form onSubmit={(e) => this._handleSubmit(e)}>
         <Header as='h3' content='Account' icon={<Icon name='user' color='green' />} />
+
+        {this._gameTypeBox()}
+
         <Form.Group widths='equal'>
           <Form.Input name='firstname' label='First Name' placeholder='First name' value={firstname} onChange={(e) => this._handleChange(e)} />
           <Form.Input name='lastname' label='Last Name' placeholder='Last name' value={lastname} onChange={(e) => this._handleChange(e)} />

--- a/client/components/team/TeamEditor.jsx
+++ b/client/components/team/TeamEditor.jsx
@@ -31,10 +31,12 @@ TeamEditor = class TeamEditor extends Component {
         password: team.password || '',
         division: team.division || null,
         lookingForMembers: (team.lookingForMembers || false),
+        inPerson: (team.inPerson || false),
         checkedIn: team.checkinConfirmed,
       };
     }
-    return { name: '', password: '', division: null, lookingForMembers: false, checkedIn: false};
+    return { name: '', password: '', division: null, lookingForMembers: false,
+      checkedIn: false, inPerson: false };
   }
 
   componentWillReceiveProps(nextProps) {
@@ -56,6 +58,18 @@ TeamEditor = class TeamEditor extends Component {
             <Input name='password' placeholder='Team Password' value={this.state.password} onChange={(e, d) => this._handleTextChange(e, d)} />
           </Form.Field>
         </Form.Group>
+
+        <Form.Field>
+          <label>Playing in-person or virtually?</label>
+          <Checkbox
+            toggle
+            name="inPerson"
+            label="If selected, your entire team MUST be present for the event. All team members must have 'in-person' ticket codes."
+            checked={ this.state.inPerson }
+            onChange={ (e, data) => this._handleDataChange(e, data) }
+            />
+        </Form.Field>
+
         <Form.Field>
           <label>Team Division <br/><small>This determines your prize group</small></label>
           <br/>
@@ -153,9 +167,9 @@ TeamEditor = class TeamEditor extends Component {
 
   _teamData() {
     const { team } = this.props;
-    const { name, password, division, lookingForMembers } = this.state;
+    const { name, password, division, lookingForMembers, inPerson, } = this.state;
     return {
-      name, password, division, lookingForMembers,
+      name, password, division, lookingForMembers, inPerson,
       _id: team ? team._id : undefined,
     };
   }

--- a/lib/collections/admin-user-methods.js
+++ b/lib/collections/admin-user-methods.js
@@ -33,6 +33,7 @@ function checkUserData(data) {
       ecEmail: ValidEmail,
       parentGuardian: String,
       photoPermission: Boolean,
+      inPersonAllowed: Boolean,
     });
   } catch (ex) {
     throw getFormError(ex);

--- a/lib/collections/teams.js
+++ b/lib/collections/teams.js
@@ -59,12 +59,13 @@ Meteor.methods({
   'teams.upsert'(team) {
     check(team, Object);
 
-    const { name, password, division, lookingForMembers } = team;
+    const { name, password, division, lookingForMembers, inPerson } = team;
 
     requirePattern(name, NonEmptyString, "You must choose a team name!");
     requirePattern(password, NonEmptyString, "You must choose a team password!");
     requirePattern(division, NonEmptyString, "You must choose a division!");
     requirePattern(lookingForMembers, Boolean, "Looking for members must be true or false!");
+    requirePattern(inPerson, Boolean, "In-Person must be true or false!");
 
     const isNewTeam = !team._id;
     const user = Meteor.user();
@@ -119,6 +120,20 @@ Meteor.methods({
     const duplicateNameTeam = Teams.findOne(opts);
     if (duplicateNameTeam) {
       throw new Meteor.Error(400, 'A team with that name already exists!');
+    }
+
+    // Check for in-person (all users must be inPersonAllowed)
+    Meteor.logger.info(`Checking for inPerson... (${inPerson})`);
+    if (inPerson) {
+      team.members.forEach(userId => {
+        const tmp_user = Meteor.users.findOne({_id: userId});
+        if (!tmp_user) {
+          throw new Meteor.Error(500, "Unable to find one or more team member users. This is probably a bug. Please contact support@greatpuzzlehunt.com");
+        }
+        if (tmp_user.inPersonAllowed !== true){
+          throw new Meteor.Error(400, "This team cannot play in person - at least one member does not have an in-person ticket code!");
+        }
+      })
     }
 
     // if team already exists check the update is comig from a current memeber:

--- a/lib/collections/users.js
+++ b/lib/collections/users.js
@@ -303,6 +303,10 @@ Meteor.methods({
     if (!ticket) { throw new Meteor.Error(400, 'That ticket code does not exist!'); }
     if (ticket.redeemed) { throw new Meteor.Error(400, 'That ticket has already been redeemed!'); }
     if (ticket.type !== user.accountType) { throw new Meteor.Error(400, `That ticket is only redeemable by ${ticket.type} accounts. You must redeem a ${user.accountType} ticket code!`); }
+    if (ticket.inPerson && !user.email.match(/@wwu.edu$/)) {
+      Meteor.logger.info(`User ${user.email} attempted to use in-person ticket code ${ticketCode} without a WWU email address`);
+      throw new Meteor.Error(400, "In-person ticket codes are only redeemable by WWU community for 2022. You must register with an @wwu.edu email address to redeem this ticket code.");
+    }
 
     const now = new Date();
     // User gets to redeem this ticket.
@@ -314,6 +318,7 @@ Meteor.methods({
     return Meteor.users.update(user._id, { $set: {
       paid: true,
       ticketUsed: ticketCode,
+      inPersonAllowed: ticket.inPerson === true,
       updatedAt: now,
     }});
   },

--- a/server/publications/users.js
+++ b/server/publications/users.js
@@ -16,6 +16,7 @@ const USER_FIELDS = {
   lookingForTeam: 1,
   bio: 1,
   photoPermission: 1,
+  inPersonAllowed: 1,
   holdHarmless: 1,
   paid: 1,
   ticketUsed: 1,


### PR DESCRIPTION
* When redeeming a ticket code, check to see if the code is for the
  in-person game. Set the user's inPersonAllowed appropriately.
* Add a message on the profile screen to remind the user if they have
  an in-person or virtual-only account set up.
* Add controls in the Admin Users screen to toggle inPersonAllowed
  for a user, regardless of their ticket code.

Remaining work: set up logic for in-person vs virtual teams