### PR TITLE
Users: add 'inPersonAllowed' functionality

### DIFF
--- a/client/components/admin/AdminUsers/imports/AdminUserEditForm.jsx
+++ b/client/components/admin/AdminUsers/imports/AdminUserEditForm.jsx
@@ -24,7 +24,7 @@ const USER_FIELDS = [
   '_id', 'firstname', 'lastname', 'email', 'accountType',
   'phone', 'age', 'address', 'city', 'zip', 'state', 'country', 'ecName',
   'ecRelationship', 'ecPhone', 'ecEmail', 'parentGuardian',
-  'photoPermission',
+  'photoPermission', "inPersonAllowed",
 ];
 
 class AdminUserEditForm extends Component {
@@ -34,7 +34,7 @@ class AdminUserEditForm extends Component {
   }
 
   _stateFromProps(props) {
-    return _.pick(props.user, USER_FIELDS);
+    return _.pick(props.user, [...USER_FIELDS, "paid"]);
   }
 
   componentWillReceiveProps(props) {
@@ -42,7 +42,7 @@ class AdminUserEditForm extends Component {
   }
 
   render() {
-    const user = _.pick(this.state, USER_FIELDS);
+    const user = _.pick(this.state, [...USER_FIELDS, "paid"]);
     return (
       <Form onSubmit={(e) => this._update(e)}>
 
@@ -93,6 +93,14 @@ class AdminUserEditForm extends Component {
           defaultChecked={user.photoPermission}
           name='photoPermission'
           label="User photo/video permission"
+          onChange={(e, data) => this._handleDataChange(e, data)} />
+
+        <Form.Checkbox
+          toggle
+          defaultChecked={user.inPersonAllowed}
+          name='inPersonAllowed'
+          label="In-person gameplay allowed"
+          disabled={!user.paid}
           onChange={(e, data) => this._handleDataChange(e, data)} />
 
         <Header as='h3' icon={<Icon name='ambulance' color='red' />}

--- a/client/components/profile/ProfileEditor.jsx
+++ b/client/components/profile/ProfileEditor.jsx
@@ -23,8 +23,44 @@ ProfileEditor = class ProfileEditor extends Component {
       lastname: user.lastname || '',
       email: user.getEmail(),
       lookingForTeam: user.lookingForTeam || false,
+      inPersonAllowed: user.inPersonAllowed,
       bio: user.bio || '',
     };
+  }
+
+  _gameTypeBox() {
+    let icon, header, content;
+    const footer = (
+      <span>For questions, see our <Link to="/contact">Contact Page</Link> or
+      our <Link to="/faq">FAQ</Link>.</span>
+    );
+
+    if (!this.state.inPersonAllowed) {
+      icon = "video camera";
+      header = "You are registered to play virtually";
+      content = (
+        <span>
+          Only WWU community members with in-person ticket codes are allowed to
+          participate in person for 2022. {footer}
+        </span>
+      );
+    } else {
+      icon = "group";
+      header = "You may play in person this year!";
+      content = (
+        <span>
+          You have purchased an in-person ticket code. If your team has the
+          "in person" setting enabled, please join us on Red Square for the
+          event. {footer}
+        </span>
+      );
+    }
+    return (
+      <Message
+        icon={icon}
+        header={header}
+        content={content} />
+    )
   }
 
   render() {
@@ -33,6 +69,9 @@ ProfileEditor = class ProfileEditor extends Component {
     <Segment basic>
       <Form onSubmit={(e) => this._handleSubmit(e)}>
         <Header as='h3' content='Account' icon={<Icon name='user' color='green' />} />
+
+        {this._gameTypeBox()}
+
         <Form.Group widths='equal'>
           <Form.Input name='firstname' label='First Name' placeholder='First name' value={firstname} onChange={(e) => this._handleChange(e)} />
           <Form.Input name='lastname' label='Last Name' placeholder='Last name' value={lastname} onChange={(e) => this._handleChange(e)} />

--- a/lib/collections/admin-user-methods.js
+++ b/lib/collections/admin-user-methods.js
@@ -33,6 +33,7 @@ function checkUserData(data) {
       ecEmail: ValidEmail,
       parentGuardian: String,
       photoPermission: Boolean,
+      inPersonAllowed: Boolean,
     });
   } catch (ex) {
     throw getFormError(ex);

--- a/lib/collections/users.js
+++ b/lib/collections/users.js
@@ -303,6 +303,10 @@ Meteor.methods({
     if (!ticket) { throw new Meteor.Error(400, 'That ticket code does not exist!'); }
     if (ticket.redeemed) { throw new Meteor.Error(400, 'That ticket has already been redeemed!'); }
     if (ticket.type !== user.accountType) { throw new Meteor.Error(400, `That ticket is only redeemable by ${ticket.type} accounts. You must redeem a ${user.accountType} ticket code!`); }
+    if (ticket.inPerson && !user.email.match(/@wwu.edu$/)) {
+      Meteor.logger.info(`User ${user.email} attempted to use in-person ticket code ${ticketCode} without a WWU email address`);
+      throw new Meteor.Error(400, "In-person ticket codes are only redeemable by WWU community for 2022. You must register with an @wwu.edu email address to redeem this ticket code.");
+    }
 
     const now = new Date();
     // User gets to redeem this ticket.
@@ -314,6 +318,7 @@ Meteor.methods({
     return Meteor.users.update(user._id, { $set: {
       paid: true,
       ticketUsed: ticketCode,
+      inPersonAllowed: ticket.inPerson === true,
       updatedAt: now,
     }});
   },

--- a/server/migrations/6_add_user_inPersonAllowed.js
+++ b/server/migrations/6_add_user_inPersonAllowed.js
@@ -1,0 +1,19 @@
+import { Meteor } from 'meteor/meteor';
+
+Migrations.add({
+	version: 6,
+	name: "Set inPersonAllowed flag to FALSE for existing users",
+	up: function () {
+		// We'll need to manually clean this up, which is doable for
+		// the small number of affected users we have at this state in
+		// registration for 2022.
+		Meteor.users.update(
+			{ inPersonAllowed: null },
+			{ $set: { inPersonAllowed: false } },
+			{ multi: true }
+		);
+	},
+	down: function () {
+		// let's keep it this way.
+	},
+});

--- a/server/migrations/run-migrations.js
+++ b/server/migrations/run-migrations.js
@@ -1,3 +1,3 @@
 Meteor.startup(() => {
-  Migrations.migrateTo('5');
+  Migrations.migrateTo('6');
 });

--- a/server/publications/users.js
+++ b/server/publications/users.js
@@ -16,6 +16,7 @@ const USER_FIELDS = {
   lookingForTeam: 1,
   bio: 1,
   photoPermission: 1,
+  inPersonAllowed: 1,
   holdHarmless: 1,
   paid: 1,
   ticketUsed: 1,


### PR DESCRIPTION
* When redeeming a ticket code, check to see if the code is for the
  in-person game. Set the user's inPersonAllowed appropriately.
* Add a message on the profile screen to remind the user if they have
  an in-person or virtual-only account set up.
* Add controls in the Admin Users screen to toggle inPersonAllowed
  for a user, regardless of their ticket code.