### PR TITLE
fix buttons going to invalid route

### DIFF
--- a/client/components/profile/ProfileTeamPreview.jsx
+++ b/client/components/profile/ProfileTeamPreview.jsx
@@ -32,7 +32,7 @@ ProfileTeamPreview = class ProfileTeamPreview extends Component {
               <Link to='/team'><Button content='View Team'/></Link>
             </Grid.Column>
             <Grid.Column width={10}>
-              <Link to='looking-for-team'>
+              <Link to='/looking-for-team'>
                 <Button basic color='violet' content='Browse other players looking to join teams!'/>
               </Link>
             </Grid.Column>

--- a/client/components/team/NoTeamMessage.jsx
+++ b/client/components/team/NoTeamMessage.jsx
@@ -25,7 +25,7 @@ NoTeamMessage = class NoTeamMessage extends Component {
           </Grid>
           { this.props.children }
           <p></p>
-          <Link to='looking-for-team'>
+          <Link to='/looking-for-team'>
             <Button basic color='violet' content='Browse other players looking to join teams!'/>
           </Link>
         </Message.Content>

--- a/client/components/team/TeamInviter.jsx
+++ b/client/components/team/TeamInviter.jsx
@@ -25,7 +25,7 @@ TeamInviter = class TeamInviter extends Component {
         <Form.Input type='text' name='email' placeholder="Friend's Email" label="Friend's Email" value={this.state.email} onChange={(e) => this._handleChange(e)}/>
         <Form.Group>
           <Form.Button type='submit' content='Invite' icon='send' labelPosition='right'/>
-          <Link to='looking-for-team'>
+          <Link to='/looking-for-team'>
             <Button basic color='violet' content='Browse other players looking to join teams!'/>
           </Link>
         </Form.Group>


### PR DESCRIPTION
Links to "looking-for-team" resulted in the route "profile/looking-for-team" and "team/looking-for-team" when clicked from the different pages. Links have been changed to "/looking-for-team" to match the defined route in routes.jsx.