### PR TITLE
automatically mark users as 'paid' on registration

### DIFF
--- a/lib/collections/users.js
+++ b/lib/collections/users.js
@@ -210,7 +210,10 @@ Meteor.methods({
     const isVolunteer = data.accountType === 'VOLUNTEER';
 
     roles.push(isVolunteer ? 'volunteer' : 'player');
-    data.paid = isVolunteer;
+    // Starting in 2023, registration is free, so user accounts will
+    // automatically be marked as "paid." If we ever go back to paid
+    // registration, change this to `data.paid = isVolunteer`.
+    data.paid = true;
     data.roles = roles;
 
     const userId = Accounts.createUser(data);


### PR DESCRIPTION
Starting in 2023, registration is free, so user accounts will automatically be marked as "paid." If we ever go back to paid registration, change this to `data.paid = isVolunteer`.