### PR TITLE
Remove rendered comments on TeamEditor

### DIFF
--- a/client/components/team/TeamEditor.jsx
+++ b/client/components/team/TeamEditor.jsx
@@ -126,13 +126,6 @@ TeamEditor = class TeamEditor extends Component {
             If you have any questions, please <Link to="/contact">Contact Us</Link>.
             <br />
           </small>
-          // <small>This setting applies to the entire team. We cannot support "mixed" teams at this point;
-          //   that is, either ALL members of the team must be in-person or ALL members must be remote.
-          //   Currently, the in-person option is only available to WWU community, and every member of your
-          //   team must have an "in-person" ticket code.
-          //   If you have any questions, please <Link to="/contact">Contact Us</Link>.
-          //   <br />
-          // </small>
           <Menu compact>
             <Menu.Item name="inPerson"
                        color="green"


### PR DESCRIPTION
A few lines of JSX were commented out using // style comments, but were not enclosed in curly braces so they were interpreted literally as slashes to be displayed on the screen. Not the first time we've been tripped up by JSX comments. Whoops!

---

Looks like the original PR was #158. Even with code review this slipped past us! Hopefully I haven't introduced anything similar in recent verbiage changes.