### PR TITLE
Transact: yet another color code

### DIFF
--- a/lib/imports/convertCashnet.js
+++ b/lib/imports/convertCashnet.js
@@ -184,6 +184,7 @@ function parseGear(params, items, i) {
             refType.includes("ALL-S-")) {
             gearItem.size = refVal
         } else if (refType.includes("COLOR") ||
+                   refType.includes("MA4-YSSHIRTC2") ||
                    refType.includes("MA4-SshirtUni") ||
                    refType.includes("MA4-YTshirtC") ||
                    refType.includes("MA4-WLSHIRT") ||


### PR DESCRIPTION
This one got missed because Transact was unable to complete the purhcase of a youth tee during initial testing (due to an issue on their end). Once that order was placed, we discovered yet another possible name for the "color" field.