### PR TITLE
Rework 'No Team' section to include matchmaking flow

### DIFF
--- a/client/components/team/NoTeamMessage.jsx
+++ b/client/components/team/NoTeamMessage.jsx
@@ -1,35 +1,72 @@
 import React, { Component } from 'react';
-import { Message, Grid, Button } from 'semantic-ui-react';
+import { Icon, Grid, Header, Segment, Divider, Button } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
 
 NoTeamMessage = class NoTeamMessage extends Component {
   render() {
     return (
-      <Message info>
-        <Message.Header>You don't have a team yet!</Message.Header>
-        <Message.Content>
-          <br/>
-          <Grid stackable>
-            <Grid.Row columns='2' widths='equal'>
-              <Grid.Column>
-                <Link to='/team/create'><Button fluid content='Create a Team' icon='right arrow' labelPosition='right'/></Link>
-                <br/>
-                Create a new team and invite your friends
-              </Grid.Column>
-              <Grid.Column>
-                <Link to='/team/join'><Button fluid content='Join a Team' icon='right arrow' labelPosition='right'/></Link>
-                <br/>
-                Browse existing teams that are looking for more members
-              </Grid.Column>
-            </Grid.Row>
-          </Grid>
-          { this.props.children }
-          <p></p>
-          <Link to='/looking-for-team'>
-            <Button basic color='violet' content='Browse other players looking to join teams!'/>
-          </Link>
-        </Message.Content>
-      </Message>
+      <Segment placeholder>
+        <Grid stackable columns={2}>
+          <Grid.Row>
+            <Grid.Column textAlign="center">
+              <Header icon>
+                <Icon name='group' color='teal' />
+                I know who I'll be playing with
+              </Header>
+            </Grid.Column>
+
+            <Grid.Column>
+              Create a new team and invite your friends
+              <Link to='/team/create'>
+                <Button fluid color='teal'
+                        content='Create a Team'
+                        icon='right arrow' labelPosition='right'/>
+              </Link>
+
+              Browse existing teams
+              <Link to='/team/join'>
+                <Button fluid color='teal'
+                        content='Join a Specific Team'
+                        icon='right arrow' labelPosition='right'/>
+              </Link>
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
+
+        <Divider horizontal color='orange'>
+          <Header as='h2'>
+            OR
+          </Header>
+        </Divider>
+
+        <Grid stackable columns={2}>
+          <Grid.Row>
+            <Grid.Column textAlign="center">
+              <Header icon>
+                <Icon name='question' color='blue'/>
+                I'm looking for others to play with
+              </Header>
+            </Grid.Column>
+
+            <Grid.Column>
+              Browse players looking for a team
+              <Link to='/looking-for-team'>
+                <Button fluid color='blue'
+                        content='Players looking for teams'
+                        icon='right arrow' labelPosition='right' />
+              </Link>
+
+              Browse teams looking for more members
+              <Link to={{pathname: '/team/join',
+                         search: '?filter=recruiting'}}>
+                <Button fluid color='blue'
+                        content='Teams looking for players'
+                        icon='right arrow' labelPosition='right'/>
+              </Link>
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
+      </Segment>
     );
   }
 }


### PR DESCRIPTION
Separate the two possible "journeys" that a user can take: join a team with people they know, or try to find others to play with. Change the team section in their profile page to make these paths clearer.

**Note:** blocked on #160 