### PR TITLE
Split registration toggle into in-person and virtual

### DIFF
--- a/client/components/admin/AdminGamestate/imports/GamestateControls.jsx
+++ b/client/components/admin/AdminGamestate/imports/GamestateControls.jsx
@@ -23,6 +23,8 @@ class GamestateControlsInner extends Component {
     if (props.gamestate) {
       this.setState({
         registration: props.gamestate.registration,
+        registrationInPersonOpen: props.gamestate.registrationInPersonOpen,
+        registrationVirtualOpen: props.gamestate.registrationVirtualOpen,
         gameplay: props.gamestate.gameplay,
         webinarURL: props.gamestate.webinarURL || "",
         webinarID: props.gamestate.webinarID || "",
@@ -62,6 +64,8 @@ class GamestateControlsInner extends Component {
 
   _renderForm() {
     const sendReportsTo = this.props.gamestate.sendReportsTo || [];
+    let registration_status = this.state.registration === true ?
+        "TRUE" : ( this.state.registration === false ? "FALSE" : "unset" );
     return (
       <Container>
         <Header as="h3" content="Emails and Reports" />
@@ -112,7 +116,10 @@ class GamestateControlsInner extends Component {
         { this._fieldButton('doSendNightlyReports', "Nightly Reports") }
 
         <Header as='h3' content='Registration and Gear'/>
-        { this._fieldButton('Registration') }
+        { /* TODO: remove this after 2023 Hunt */ }
+        <small>Deprecated 'register' state: {`${registration_status}`}</small>
+        { this._fieldButton('registrationInPersonOpen', 'In-Person Registration') }
+        { this._fieldButton('registrationVirtualOpen', 'Virtual Registration') }
         { this._fieldButton('buyGear', '"Buy Gear" Button (on homepage)') }
 
         <Header as='h3' content='Webinar'/>

--- a/client/components/profile/ProfileEditor.jsx
+++ b/client/components/profile/ProfileEditor.jsx
@@ -36,7 +36,7 @@ ProfileEditorUI = class ProfileEditor extends Component {
   render() {
     const { firstname, lastname, gameMode, lookingForTeam, bio } = this.state;
     const { ready, gamestate } = this.props;
-    const canChangeGameMode = ready && gamestate.registration;
+    const canChangeGameMode = ready && gamestate.registrationInPersonOpen;
     return (
     <Segment basic>
       <Form onSubmit={(e) => this._handleSubmit(e)}>

--- a/client/components/public/imports/HomeEarlyBird.jsx
+++ b/client/components/public/imports/HomeEarlyBird.jsx
@@ -9,7 +9,9 @@ const { eventYear, registrationOpenDate, earlyBirdLastDate, regularRegistrationS
 class HomeEarlyBird extends Component {
   render() {
     const { gamestate } = this.props;
-    const registrationOpen = gamestate && gamestate.registration;
+    const registrationOpen = gamestate &&
+          this.props.gamestate.registrationInPersonOpen &&
+          this.props.gamestate.registrationInPersonOpen;
     let registerButton = (
       <a style={{textDecoration:"none", fontSize: "36pt", padding: "40px", borderRadius: "10px", backgroundColor: "#bad80a", color:"black"}}>Register</a>
     );

--- a/client/components/register/Register.jsx
+++ b/client/components/register/Register.jsx
@@ -24,7 +24,8 @@ class RegisterInner extends Component {
         border: '0',
     };
 
-    if (gamestate.registration) {
+    if (gamestate.registrationInPersonOpen ||
+        gamestate.registrationVirtualOpen) {
       content = (
         <Segment basic>
           <RegisterForm />
@@ -32,13 +33,13 @@ class RegisterInner extends Component {
       );
     } else {
       content = (
-		<div>
-        	<Message
-          info size='large'
-          header='Registration is Closed'
-			  content={`Registration for the ${eventYear} Great Puzzle Hunt will open ${registrationOpenDate}.`}
-			/>
-		</div>
+	<div>
+          <Message
+            info size='large'
+            header='Registration is Closed'
+	    content={`Registration is closed at this time.`}
+	  />
+	</div>
       );
     }
 

--- a/client/components/register/imports/RegisterForm.jsx
+++ b/client/components/register/imports/RegisterForm.jsx
@@ -11,7 +11,7 @@ import { Segment,
   Radio,
 } from 'semantic-ui-react';
 import { pick } from 'lodash';
-import { gameModeOptions } from '../../../../lib/imports/util'
+import { gameModeOptions, gameModeEnum, } from '../../../../lib/imports/util'
 
 import GamestateComp from '../../imports/GamestateComp';
 
@@ -138,7 +138,8 @@ class RegisterForm extends Component {
   render() {
     if (!this.props.ready) {
       return <Loading/>
-    } else if (this.props.gamestate.registration) {
+    } else if (this.props.gamestate.registrationInPersonOpen ||
+               this.props.gamestate.registrationVirtualOpen) {
       return this._renderMain();
     } else {
       return <Message
@@ -222,8 +223,7 @@ class RegisterForm extends Component {
                          selection options={gameModeOptions} value={ this.state.gameMode }
                          onChange={ (e, data) => this._handleDataChange(e, data) }/>
         </Form.Group>
-
-        <p><strong>Note:</strong> game mode can be changed until {registrationCloseDate}.</p>
+        { this._gameModeNote(this.props.gamestate.registrationInPersonOpen) }
 
         <Header as='h3' icon={<Icon name='home' color='blue'/>} content='Player Details'
                 subheader='This information is required in the case of emergency.'/>
@@ -326,6 +326,24 @@ class RegisterForm extends Component {
       if (error) return this.setState({ error, mode: 'register' });
       this.setState({ error: null, result, mode: 'thankyou' });
     });
+  }
+
+  _gameModeNote(inPersonOpen) {
+    if (inPersonOpen) {
+      return (
+        <p><strong>Note:</strong> game mode can be changed
+          until {registrationCloseDate}.
+        </p>
+      );
+    } else {
+      return (
+        <Message
+          color='yellow'
+          header='In-person registration is now closed'
+          content="We are no longer accepting additional in-person players for this year"
+        />
+      );
+    }
   }
 
   _registrationData() {

--- a/lib/collections/users.js
+++ b/lib/collections/users.js
@@ -231,13 +231,21 @@ Meteor.methods({
     // check that country, state, and zip/postal code make sense
     checkCountryState(data);
     checkPostalCode(data.country, data.zip);
-    checkPhoneNumbers(data.country, data.phone, data.ecPhone);  
+    checkPhoneNumbers(data.country, data.phone, data.ecPhone);
 
-    // 2. Register User
+    // 2. Configure role
     const roles = ['user'];
     const isVolunteer = data.accountType === 'VOLUNTEER';
-
     roles.push(isVolunteer ? 'volunteer' : 'player');
+
+    // 3. Check in-person registration limit
+    if (!isVolunteer && data.gameMode === "INPERSON") {
+      if (Gamestate.findOne({}).registrationInPersonOpen === false) {
+        throw new Meteor.Error(400,
+          "Sorry, We can no longer accept in-person players at this time");
+      }
+    }
+
     // Starting in 2023, registration is free, so user accounts will
     // automatically be marked as "paid." If we ever go back to paid
     // registration, change this to `data.paid = isVolunteer`.
@@ -245,6 +253,8 @@ Meteor.methods({
     data.roles = roles;
 
     const userId = Accounts.createUser(data);
+    // Meteor.logger.info("New player registered:");
+    // Meteor.logger.info(data);
     Accounts.sendVerificationEmail(userId);
   },
 


### PR DESCRIPTION
We need to be able to turn off in-person registration ahead of the game, either when capacity is reached or the deadline is up. However, we'd still like to keep virtual registration open until closer to the event itself.

This commit splits the functionality such that both options can be enabled or disabled independently. Turning off in-person registration also disables the user's ability to toggele their profile between in-person and virtual. Team toggles are unaffected because the team setting has more to do with puzzle delivery through the system than it does with the players' physical locations.