### PR TITLE
Fix: replaceAll doesn't exist

### DIFF
--- a/lib/collections/teams.js
+++ b/lib/collections/teams.js
@@ -428,7 +428,7 @@ Meteor.methods({
 
     const i = findIndex(team.puzzles, (p) => p.puzzleId === puzzleId);
     const nonCharacterDigit = /[^a-zA-Z0-9]/ug
-    const cleanAnswer = answer.replaceAll(nonCharacterDigit, '').toLowerCase();
+    const cleanAnswer = answer.replace(nonCharacterDigit, '').toLowerCase();
 
     const isNonCompetitive = team.division === "noncompetitive";
 


### PR DESCRIPTION
It seems String.replaceAll() doesn't work in Node on the server side. This logic seems okay in the browser, but not the server. This means that puzzle answers fail with an error.

Note that because the regex already ends in /g (global), the intended functionality is unchanged.