### PR TITLE
Fix "Created" column wrong date in admin team list

### DIFF
--- a/server/publications/teams.js
+++ b/server/publications/teams.js
@@ -5,6 +5,7 @@ Meteor.publish('admin.teams', function() {
   if (!isAdmin(this.userId)) return this.ready();
 
   const projection = {
+    createdAt: 1,
     name: 1,
     division: 1,
     checkinConfirmed: 1,


### PR DESCRIPTION
The "createdAt" property was not being published to the admin teams page, so the UI defaulted to displaying the current time instead of the true creation time.