### PR TITLE
Adjust UI when matchmaking team is full

### DIFF
--- a/client/components/team/TeamListCard.jsx
+++ b/client/components/team/TeamListCard.jsx
@@ -42,7 +42,8 @@ TeamListCard = class TeamListCard extends Component {
   render() {
     const { division, showPasswordField, memberCount, inPerson, } = this.state;
     const { team } = this.props;
-    const membersLabel = `${memberCount} of 6 members`;
+    const membersLabelPostfix = this.state.isFull ? " (full)" : "";
+    const membersLabel = `${memberCount} of 6 members ${membersLabelPostfix}`;
     const membersPercent = Math.round((memberCount / 6)*100);
     const progressColor = this._getProgressColor(memberCount);
 
@@ -87,7 +88,6 @@ TeamListCard = class TeamListCard extends Component {
     }
 
     const { showPasswordField, isFull, showOwner, lookingForMembers } = this.state;
-    if (isFull) return null;
 
     let lookingBtn = null;
     if (!showPasswordField && lookingForMembers) {
@@ -103,6 +103,16 @@ TeamListCard = class TeamListCard extends Component {
         />;
     }
     const ownerInfo = showOwner ? this._renderOwnerInfo() : null;
+
+    if (isFull) {
+      // Still allow players to message the team, but not join it
+      return (
+        <Card.Content extra>
+          { lookingBtn }
+          { ownerInfo }
+        </Card.Content>
+      );
+    }
 
     const joinBtn = !showOwner && !showPasswordField ? <Button basic size='small' floated='right' icon='reply' labelPosition='right' content='Join Team' onClick={() => this.setState({ showPasswordField: true })}/> : null;
     const passwordForm = showPasswordField ? this._renderPasswordField() : null;


### PR DESCRIPTION
When a team is full but still listed as "Looking for Members," add the string "(full)" to the end of their team size. Additionally, keep the ability to message the team captain even if they are full.

normal team:

<img width="272" alt="Screen Shot 2023-04-15 at 12 52 45 PM" src="https://user-images.githubusercontent.com/12406521/232251322-9ceb52f4-27ee-4890-b72e-388be7fa1cf7.png">

full team:

<img width="277" alt="Screen Shot 2023-04-15 at 1 09 12 PM" src="https://user-images.githubusercontent.com/12406521/232251337-5fb395a9-a9be-4b51-abd1-bf1054687a95.png">
