### PR TITLE
Add user _id values to admin user detail and admin team user list

### DIFF
--- a/client/components/admin/AdminTeams/imports/AdminTeamUserList.jsx
+++ b/client/components/admin/AdminTeams/imports/AdminTeamUserList.jsx
@@ -42,6 +42,7 @@ AdminTeamUserList = class AdminTeamsUserList extends Component {
                     <em>{user.accountType}</em>
                 </Table.Cell>
                 <Table.Cell>{user.name}</Table.Cell>
+                <Table.Cell>{user._id}</Table.Cell>
                 <Table.Cell positive={checkedIn} negative={!checkedIn}>
                     {checkedIn ? "Checked In" : "NOT Checked In"}
                 </Table.Cell>
@@ -90,6 +91,7 @@ AdminTeamUserList = class AdminTeamsUserList extends Component {
                     <Table.Row>
                         <Table.HeaderCell>Acct Type</Table.HeaderCell>
                         <Table.HeaderCell>Name</Table.HeaderCell>
+                        <Table.HeaderCell>Id</Table.HeaderCell>
                         <Table.HeaderCell>Check-in Status</Table.HeaderCell>
                         <Table.HeaderCell>Remove</Table.HeaderCell>
                     </Table.Row>

--- a/client/components/admin/AdminUsers/imports/AdminUserEditForm.jsx
+++ b/client/components/admin/AdminUsers/imports/AdminUserEditForm.jsx
@@ -50,7 +50,7 @@ class AdminUserEditForm extends Component {
         {this._errorMessage()}
 
         <Header as='h3' icon={<Icon name='user' color='blue' />}
-                content='Player Details'
+                content={`Player Details (id ${user._id})`}
                 subheader='This information is required in the case of emergency.' />
 
         <Form.Group widths='equal'>


### PR DESCRIPTION
This is a minor Trello issue: "Add user id value to admin team detail dialog and admin user detail dialog". 

I'd suggest people see if they like the addition; if so, we can merge the PR and if not, we can abandon it.