### PR TITLE
bug fix on team progress modal dialog

### DIFF
--- a/client/components/admin/AdminTeams/imports/AdminTeamModalProgress.jsx
+++ b/client/components/admin/AdminTeams/imports/AdminTeamModalProgress.jsx
@@ -54,6 +54,10 @@ class AdminTeamModalProgress extends Component {
     const { team } = this.props;
     const { puzzles } = team;
 
+    if ((puzzles == undefined) || !team.hasBegun) {
+      return ( <div> Team has not started game (yet) </div> );
+    }
+
     const puzzlesCt = puzzles.length;
     const puzzlesComplete = puzzles.reduce((acc, puzzle) => {
         return acc + ( puzzle.end ? 1 : 0 );

--- a/client/components/admin/AdminTeams/imports/AdminTeamModalProgress.jsx
+++ b/client/components/admin/AdminTeams/imports/AdminTeamModalProgress.jsx
@@ -54,7 +54,7 @@ class AdminTeamModalProgress extends Component {
     const { team } = this.props;
     const { puzzles } = team;
 
-    if ((puzzles == undefined) || !team.hasBegun) {
+    if ((puzzles === undefined) || !team.hasBegun) {
       return ( <div> Team has not started game (yet) </div> );
     }
 


### PR DESCRIPTION
Fix a bug that was producing a blank page when an admin tries to look at a team's progress but game play has not yet started