### PR TITLE
Improve user registration validation

### DIFF
--- a/lib/collections/users.js
+++ b/lib/collections/users.js
@@ -135,9 +135,6 @@ function checkParentGuardian(age, parentGuardian) {
   if (age < 14) {
     checkSomeTextData('parentGuardian', parentGuardian, 3);
   }
-  // if ((age < 14) && (parentGuardian.length === 0)) {
-  //   throw new Meteor.Error(400, errorMap['parentGuardian']);
-  // }
 }
 
 // Check if the country entered is for the United States.

--- a/lib/collections/users.js
+++ b/lib/collections/users.js
@@ -132,9 +132,12 @@ function checkPassword(password1, password2, minLength = PASSWORD_MIN_LENGTH) {
 }
 
 function checkParentGuardian(age, parentGuardian) {
-  if ((age < 14) && (parentGuardian.length === 0)) {
-    throw new Meteor.Error(400, errorMap['parentGuardian']);
+  if (age < 14) {
+    checkSomeTextData('parentGuardian', parentGuardian, 3);
   }
+  // if ((age < 14) && (parentGuardian.length === 0)) {
+  //   throw new Meteor.Error(400, errorMap['parentGuardian']);
+  // }
 }
 
 // Check if the country entered is for the United States.
@@ -184,6 +187,22 @@ function checkPhoneNumbers(country, playerPhone, ecPhone) {
   x = ecPhone.replace(/\D/g, '');
   if (x.length != 10) {
     throw new Meteor.Error(400, 'Valid emergency contact phone number required for US and Canadian addresses');
+  }
+}
+
+
+// check a value to make sure it has some meaningful content -- not
+// blank, a dash, and so on. Assumes that the field has already been
+// checked to be a non-empty string
+function checkSomeTextData(fieldName, value, minLength) {
+  const invalidTextData = ['-', '--', '*'];
+
+  if ((value.trim().length < minLength) ||  invalidTextData.includes(value.trim())) {
+    throw new Meteor.Error(400, errorMap[fieldName]);
+  }
+  const count = (value.match(/[A-Za-z]/g) || []).length;
+  if (count < minLength) {
+    throw new Meteor.Error(400, errorMap[fieldName]);
   }
 }
 
@@ -245,6 +264,16 @@ Meteor.methods({
           "Sorry, We can no longer accept in-person players at this time");
       }
     }
+
+    // 4. Check that several fields have useful information in them
+    checkSomeTextData('firstname', data.firstname, 1); 
+    checkSomeTextData('lastname', data.lastname, 2);
+    checkSomeTextData('address', data.address, 2);
+    checkSomeTextData('city', data.city, 2);
+    checkSomeTextData('country', data.country, 2);
+    checkSomeTextData('ecName', data.ecName, 3);
+    checkSomeTextData('ecRelationship', data.ecRelationship, 3);
+    
 
     // Starting in 2023, registration is free, so user accounts will
     // automatically be marked as "paid." If we ever go back to paid


### PR DESCRIPTION
This fix changes the validation for several user registration fields: first and last names, address, city, country, emergency contact name and relationship, and parent/guardian. These fields now must have some number of alphabetic characters in their values. (The number of letters required depends on the field.)

Note that this validation will only pass with regular Latin characters—it does not try to support the full range of unicode alphabetic letters across multiple languages.