### PR TITLE
Clarify external link variable names

### DIFF
--- a/client/components/public/imports/HomeDonate0.jsx
+++ b/client/components/public/imports/HomeDonate0.jsx
@@ -4,7 +4,7 @@ import { Container, Grid, Segment, Header, Icon, Image } from 'semantic-ui-react
 import LinkButton from '../../imports/LinkButton';
 
 const { eventYear } = Meteor.settings.public;
-let link = `https://commerce.cashnet.com/TheGreatPuzzleHunt${eventYear}`;
+const donation_link = "https://foundation.wwu.edu/greatpuzzlehunt";
 
 export default class HomeDonate0 extends Component {
   render() {
@@ -31,7 +31,7 @@ export default class HomeDonate0 extends Component {
                 <p>Donations of any amount will help support this event.</p>
               </Segment>
               <LinkButton as='a'
-                href={link}
+                href={donation_link}
                 size='large'  content='Donate Online'
                 icon={<Icon name='heart'/>}
                 color="green"

--- a/client/components/public/imports/HomeEarlyBird.jsx
+++ b/client/components/public/imports/HomeEarlyBird.jsx
@@ -16,14 +16,14 @@ class HomeEarlyBird extends Component {
       <a style={{textDecoration:"none", fontSize: "36pt", padding: "40px", borderRadius: "10px", backgroundColor: "#bad80a", color:"black"}}>Register</a>
     );
 
-    let link = `https://commerce.cashnet.com/TheGreatPuzzleHunt${eventYear}`;
+    let cashnet_link = `https://commerce.cashnet.com/TheGreatPuzzleHunt${eventYear}`;
 
     let urls = ["#", "#", "#", "#"];
     if (registrationOpen) {
       registerButton = (
         <a href="/register" target="_blank" style={{textDecoration:"none", fontSize: "36pt", padding: "40px", borderRadius: "10px", backgroundColor: "#bad80a", color:"black"}}>Register</a>
       );
-      urls = ["/register", link, "/redeem", "/team"];
+      urls = ["/register", cashnet_link, "/redeem", "/team"];
     }
 
     return (

--- a/client/components/public/imports/HomeHeader.jsx
+++ b/client/components/public/imports/HomeHeader.jsx
@@ -14,7 +14,7 @@ const { eventYear, eventDate, eventDay, earlyBirdLastDate, registrationCloseDate
 
 /* TODO: these two components should be on timers, and the official times should be
    stored in a well-known place with a well known (ISO 8601, anyone?) format. */
-let link = `https://commerce.cashnet.com/TheGreatPuzzleHunt${eventYear}`;
+let cashnet_link = `https://commerce.cashnet.com/TheGreatPuzzleHunt${eventYear}`;
 
 const registerNowMessage = (
   <Message icon color='teal'>
@@ -33,7 +33,7 @@ const registrationClosesMessage = (
       <Message.Header>Why Register Now?</Message.Header>
       Step 1 of Registration Closes {registrationCloseDate}, 11:59 PM. <br/>
       Gear sales are closed, but
-      you can still <a href={link} target="_blank">buy and redeem tickets</a> until 10:00 AM {eventDay}, {eventDate}.
+      you can still <a href={cashnet_link} target="_blank">buy and redeem tickets</a> until 10:00 AM {eventDay}, {eventDate}.
     </Message.Content>
   </Message>
 );


### PR DESCRIPTION
The Transact/CashNet gear page and the foundation donation page have separate links, but were both often named `link`. This led to the Transact link being used where the Foundation link should have been.