### PR TITLE
Add ability to mark a team ineligible for prizes

### DIFF
--- a/client/components/admin/AdminLeaderboard/imports/AdminLeaderboardDivisionTable.jsx
+++ b/client/components/admin/AdminLeaderboard/imports/AdminLeaderboardDivisionTable.jsx
@@ -77,9 +77,10 @@ class AdminLeaderboardDivisionTable extends Component {
       falsey={<Icon name="video" color="yellow" />}
       />;
 
-    const dispName = (prize_ineligible && !userIsAdmin) ? '(redacted)' : name
+    const isPrizeIneligible = prize_ineligible ? true : false;
+    const dispName = (isPrizeIneligible && !userIsAdmin) ? '(redacted, ineligible)' : name
     const ineligible = <MaybeNullIcon
-			 value={prize_ineligible && userIsAdmin}
+			 value={isPrizeIneligible && userIsAdmin}
 			 truthy={<Icon name='eye slash' color='red' />}
 			 falsey={ ' ' }
 		       />;

--- a/client/components/admin/AdminLeaderboard/imports/AdminLeaderboardMain.jsx
+++ b/client/components/admin/AdminLeaderboard/imports/AdminLeaderboardMain.jsx
@@ -18,10 +18,11 @@ class AdminLeaderboardMain extends Component {
   }
 
   _stateFromProps(props) {
-    const { teams } = props;
+    const { user, teams } = props;
 
     return {
       teamsByDivision: groupBy(teams, (team) => team.division),
+      user: user,
     };
   }
 
@@ -38,15 +39,16 @@ class AdminLeaderboardMain extends Component {
   }
 
   _renderDivisions() {
-    const { teamsByDivision } = this.state;
+    const { user, teamsByDivision } = this.state;
     return Object.keys(teamsByDivision).map((division) => {
-      return <AdminLeaderboardDivisionTable division={DIVISION_MAP[division]} teams={teamsByDivision[division]} key={division}/>
+      return <AdminLeaderboardDivisionTable user={user} division={DIVISION_MAP[division]} teams={teamsByDivision[division]} key={division}/>
     });
   }
 }
 
 AdminLeaderboardMain.propTypes = {
   teams: PropTypes.arrayOf(Object).isRequired,
+  user: PropTypes.object.isRequired,
 };
 
 export default AdminLeaderboardMain;

--- a/client/components/admin/AdminTeams/imports/AdminTeamModalGeneral.jsx
+++ b/client/components/admin/AdminTeams/imports/AdminTeamModalGeneral.jsx
@@ -37,6 +37,15 @@ class AdminTeamModalGeneral extends Component {
             if (err) alert(err);
         });
     }
+    _toggleIneligible(e){
+        e.preventDefault();
+        const { team } = this.props;
+        if(!confirm(`Are you SURE you want to toggle the eligibility status for  team "${team.name}"?`)) return;
+
+        Meteor.call('admin.team.toggleIneligible', team._id, err => {
+            if (err) alert(err);
+        });
+    }
     render() {
         const { team } = this.props;
 
@@ -64,6 +73,15 @@ class AdminTeamModalGeneral extends Component {
                   onClick={this._toggleInPerson.bind(this)}
                   content={team.inPerson ? "Team playing in-person" : "Team playing virtually"}
                   />
+                <br /><br />
+
+                <Button
+                    label="Marking a team ineligible indicates they should not be listed on public leaderboards"
+                    color={team.prize_ineligible ? 'green' : 'red'}
+                    onClick={this._toggleIneligible.bind(this)}
+                    icon={<Icon name={team.prize_ineligible ? 'unlock' : 'lock'} />}
+                    content={team.prize_ineligible ? "Mark team eligible" : "Mark team ineligible (DANGER)"}
+                />
                 <br /><br />
 
                 <Button

--- a/client/components/admin/AdminTeams/imports/AdminTeamTable.jsx
+++ b/client/components/admin/AdminTeams/imports/AdminTeamTable.jsx
@@ -50,7 +50,7 @@ class AdminTeamTable extends Component {
     return (
       <div>
 	<Message icon>
-	  <Icon name="teal address book"/>
+	  <Icon name="address book" color="teal"/>
 	  <Message.Content>
             <Message.Header>
 	      Teams Summary

--- a/client/components/admin/AdminTeams/imports/AdminTeamTableRow.jsx
+++ b/client/components/admin/AdminTeams/imports/AdminTeamTableRow.jsx
@@ -15,12 +15,19 @@ class AdminTeamTableRow extends Component {
     if (!team) {
       return <Table.Row negative>MISSING TEAM!</Table.Row>;
     }
-    const { EMERGENCY_LOCK_OUT } = team;
+    const { EMERGENCY_LOCK_OUT, prize_ineligible } = team;
+
+    const isPrizeIneligible = prize_ineligible ? true : false;
+    const ineligible = <MaybeNullIcon
+			 value={isPrizeIneligible}
+			 truthy={<Icon name='eye slash' color='red' />}
+			 falsey={ ' ' }
+		       />;
 
     return (
       <Table.Row error={EMERGENCY_LOCK_OUT}>
         <Table.Cell>{this._createdAt()}</Table.Cell>
-        <Table.Cell>{this._name()}</Table.Cell>
+        <Table.Cell>{this._name()} {ineligible}</Table.Cell>
         <Table.Cell>{this._division()}</Table.Cell>
         <Table.Cell>{this._checkedIn()}</Table.Cell>
         <Table.Cell>{this._hasBegun()} {this._lockout(EMERGENCY_LOCK_OUT)}</Table.Cell>

--- a/lib/collections/teams.js
+++ b/lib/collections/teams.js
@@ -632,4 +632,21 @@ Meteor.methods({
     });
   },
 
+  'admin.team.toggleIneligible'(teamId) {
+    check(teamId, String);
+    requireAdmin();
+    if (!Meteor.isServer) return true;
+
+    const team = Teams.findOne(teamId);
+    if (!team) throw new Meteor.Error(400, `Oops, no team found with id ${teamId}`);
+    const currVal = team.prize_ineligible || false;
+    Meteor.logger.info(`marking team ${teamId} ${currVal ? "eligible" : "ineligible"} for prizes`);
+
+    return Teams.update(teamId, {
+      $set: {
+        prize_ineligible: !currVal,
+      }
+    });
+  },
+
 });

--- a/lib/imports/puzzle-helpers.js
+++ b/lib/imports/puzzle-helpers.js
@@ -10,7 +10,9 @@ const HINT_PENALTY = {
 
 export function getHintsTaken(puzzleOrHints){
   let hints = puzzleOrHints;
-  if(hints.hints) hints = hints.hints;
+  if (hints.hints) {
+    hints = hints.hints;
+  }
   return hints.reduce((accum, currVal) => accum + (currVal.taken ? 1 : 0), 0);
 }
 

--- a/lib/imports/sendReports.js
+++ b/lib/imports/sendReports.js
@@ -211,42 +211,43 @@ function buildUsersAndTeams() {
 }
 
 function buildLeaderboard() {
-		const users = Meteor.users.find({teamId: { $exists: true }}).fetch();
-		const teams = Teams.find({}).fetch().reduce((acc, team) => {
-				acc[team._id] = team;
-				return acc;
-		}, {});
-		const fields = [
-				"teamName", "teamDivision", "score", "teamIsPlaying",
-				"teamInPerson", "gameMode",
-				"checkedIn", "firstname", "lastname", "phone", "photoPermission",
-				"age", "city", "state", "address", "zip", "country",
-		];
-		const usersWithTeams = sortBy(users.map((user) => {
-				if (user.teamId) {
-						const team = teams[user.teamId];
-						user.teamDivision = team.division;
-						user.teamName = team.name;
-						user.teamIsPlaying = team.hasBegun;
-						user.teamSize = team.members.length;
-						user.teamInPerson = team.inPerson;
-						user.score = getFinalScoreIfFinished(team);
-
-						user.checkedIn = Boolean(user.checkedIn);
-				}
-				return user;
-		}), ['division', 'teamName', 'firstname', 'lastname']);
-
-		let csv = fields.join(",") + "\n";
-		usersWithTeams.forEach((user) => {
-				csv += fields.map((field) => `"${user[field] || ''}"`).join(",") + "\n";
-		});
-
-		return {
-				filename: `leaderboard.csv`,
-				content: csv,
-				encoding: 'utf-8',
-		};
+  const users = Meteor.users.find({teamId: { $exists: true }}).fetch();
+  const teams = Teams.find({}).fetch().reduce((acc, team) => {
+    acc[team._id] = team;
+    return acc;
+  }, {});
+  const fields = [
+    "teamName", "eligible", "teamDivision", "score",
+    "teamIsPlaying", "teamInPerson", "gameMode",
+    "checkedIn", "firstname", "lastname", "phone", "photoPermission",
+    "age", "city", "state", "address", "zip", "country",
+  ];
+  const usersWithTeams = sortBy(users.map((user) => {
+    if (user.teamId) {
+      const team = teams[user.teamId];
+      user.eligible = team.prize_ineligible ? 'no' : '';
+      user.teamDivision = team.division;
+      user.teamName = team.name;
+      user.teamIsPlaying = team.hasBegun;
+      user.teamSize = team.members.length;
+      user.teamInPerson = team.inPerson;
+      user.score = getFinalScoreIfFinished(team);
+      
+      user.checkedIn = Boolean(user.checkedIn);
+    }
+    return user;
+  }), ['division', 'eligible', 'teamName', 'firstname', 'lastname']);
+  
+  let csv = fields.join(",") + "\n";
+  usersWithTeams.forEach((user) => {
+    csv += fields.map((field) => `"${user[field] || ''}"`).join(",") + "\n";
+  });
+  
+  return {
+    filename: `leaderboard.csv`,
+    content: csv,
+    encoding: 'utf-8',
+  };
 }
 
 export function sendLeaderboard(to = null) {

--- a/server/publications/teams.js
+++ b/server/publications/teams.js
@@ -12,6 +12,8 @@ Meteor.publish('admin.teams', function() {
     inPerson: 1,
     hasBegun: 1,
     owner: 1,
+    prize_ineligible: 1,
+    EMERGENCY_LOCK_OUT: 1,
     'puzzles.start': 1,
     'puzzles.end': 1,
     'puzzles.name': 1,

--- a/server/publications/teams.js
+++ b/server/publications/teams.js
@@ -14,9 +14,7 @@ Meteor.publish('admin.teams', function() {
     owner: 1,
     prize_ineligible: 1,
     EMERGENCY_LOCK_OUT: 1,
-    'puzzles.start': 1,
-    'puzzles.end': 1,
-    'puzzles.name': 1,
+    puzzles: 1,
   }
   return Teams.find({}, {fields: projection});
 });


### PR DESCRIPTION
- add a prize_ineligible field to teams (default is eligible)
- add ability toggle eligibility to admin team edit dialog
- fixed bug in toggling eligibility and lockout (problem with meteor publication)
- on admin leaderboard, mark ineligible teams with a red slash eye icon
- on public leaderboard, show ineligible teams as "redacted, ineligible" along with icon
- on admin team list, mark ineligible teams with the icon
- on leaderboard report, add a column for "eligible"