### PR TITLE
Update gear shipping/delivery dates for 2024

### DIFF
--- a/client/components/public/FAQ.jsx
+++ b/client/components/public/FAQ.jsx
@@ -44,7 +44,7 @@ const gearPricing = (
     <ul>
       <li>Prices on varying styles range from $20&ndash;$35, additional $2 for extended sizes. Gear store open {regularRegistrationStart}&ndash;{gearSaleEnd}.</li>
       <li>Gear sales end midnight {gearSaleEnd}.</li>
-      <li>Shirts will be ordered on Monday, April 17 and assuming no supply chain delays, should be shipped out or ready for pick-up by the end of the week of April 24.</li>
+      <li>Shirts will be ordered on Monday, April 22 and assuming no supply chain delays, should be shipped out or ready for pick-up by the end of the week of May 6, 2024.</li>
       <li>The sale of these shirts helps fund this event. Support the WWU Great Puzzle Hunt and wear our official Great Puzzle Hunt gear! Check out the styles, colors, and design.</li>
     </ul>
     <p> If you are able, please consider making a small donation (suggested $5 students, $10 nonstudents) and/or buying a shirt (our only fund raiser). Donations of any amount will help sustain this event. </p>


### PR DESCRIPTION
Per Millie, gear page should read:
  Gear store closes April 21, 2024.
  Shirts will be ordered on Monday, April 22, 2024, and assuming no
  supply chain delays, should be shipped out or ready for pick-up the
  week of May 6, 2024.