### PR TITLE
Re-enable page subtitles

### DIFF
--- a/client/components/public/Media.jsx
+++ b/client/components/public/Media.jsx
@@ -8,7 +8,7 @@ Media = class Media extends Component {
     return (
       <Container className="section">
       <Segment basic>
-        <PuzzlePageTitle title="Media" subTitle={<span>Photo Credit: <a href="http://www.gabrielleponcz.com/" target="_blank">Gabrielle Poncz</a></span>} />
+        <PuzzlePageTitle title="Media" />
 
         <h2 style={{fontWeight: "600"}}>Check out videos of past Hunts on our 
         <a href="https://www.youtube.com/channel/UCTc814_FbilFiSVktIWec8A" target="_blank">

--- a/client/components/public/PuzzlePageTitle.jsx
+++ b/client/components/public/PuzzlePageTitle.jsx
@@ -7,10 +7,14 @@ PuzzlePageTitle = class PuzzlePageTitle extends Component {
     const smallStyle = {
       fontSize: '.65em',
     };
+    const SubTitle = this.props.subTitle ?
+          <small style={ smallStyle }><br />{this.props.subTitle}</small>
+          :
+          "";
     return (
        <h1 className='dark-blue'>
          {this.props.title}
-         {/* <small style={ smallStyle }>{this.props.subTitle}</small> */}
+         {SubTitle}
         </h1>
     );
   }


### PR DESCRIPTION
A few pages had subtitles that included helpful context, such as the name of the team a volunteer was checking in. These got disabled at some point during a site layout redesign; however, from spot checking the few pages that still passed a subTitle prop, I don't see any reason why this can't come back.