### PR TITLE
Add a "Give Up" feature for all teams

### DIFF
--- a/client/components/game/imports/NCGiveUp.jsx
+++ b/client/components/game/imports/NCGiveUp.jsx
@@ -2,15 +2,45 @@ import { Meteor } from 'meteor/meteor';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Confirm, Segment } from 'semantic-ui-react';
+import moment from 'moment';
 
 export default class GiveUp extends React.Component {
+    server_poll_count = 0;
     constructor(props) {
         super(props);
         this.state = {
             showConfirm: false,
-            loading: false
-        }
+            loading: false,
+            now: null,
+        };
         this._handleClick = this._handleClick.bind(this);
+        this._enabled = this._enabled.bind(this);
+
+        // Polling logic based on client/components/imports/PuzzleProgress.jsx
+        const hasEnded = Boolean(props.puzzle.end);
+        if (!hasEnded) {
+            const _this = this;
+            // Update our clock from the server once per minute to reduce skew.
+            this.interval = Meteor.setInterval(() => {
+                if (this.server_poll_count % 60 === 0) {
+                  Meteor.call('serverTime', (err, time) => {
+                    if (err) {
+                      console.warn("GiveUp component failed to fetch server time");
+                      console.warn(err);
+                      _this.setState({ now: moment() });
+                    }
+                    else _this.setState({ now: moment(time) });
+                  });
+                } else {
+                    _this.setState({ now: moment(_this.state.now).add(1, 'second') });
+                }
+                this.server_poll_count++;
+            }, 1000);
+        }
+    }
+
+    componentWillUnmount() {
+        Meteor.clearInterval(this.interval);
     }
 
     _doGiveUp(){
@@ -19,8 +49,11 @@ export default class GiveUp extends React.Component {
         this.setState({loading: true});
 
         Meteor.call("team.puzzle.giveUp", puzzleId, teamId, (error, result)=>{
+            if (error) {
+                console.log(error);
+                alert(`Unable to give up: ${error.reason}. Please talk to a volunteer`);
+            }
             this.setState({loading: false});
-            if(error) return alert(error.reason);
         });
     }
 
@@ -36,8 +69,8 @@ export default class GiveUp extends React.Component {
     
         Meteor.call('team.puzzle.answer', puzzle.puzzleId, answer, (error, result) => {
           this.setState({ answer: '' });
-          if (error) return this.setState({ error });
-          if (result.message) {
+          if (error) this.setState({ error });
+          else if (result.message) {
             this.setState({ message: result.message });
             Meteor.setTimeout(() => this.setState({ message: null }), 2000);
           }
@@ -51,26 +84,41 @@ export default class GiveUp extends React.Component {
             open={showConfirm}
             header="Are you sure?"
             content={<Segment basic style={{fontSize: '16px'}}>
-              <p>Are you sure you want to end this puzzle and get the answer?</p>
+                       <p>Are you sure you want to end this puzzle and get the answer?</p>
+                       <p>You will receive the full timeout score for this puzzle!</p>
             </Segment>}
             confirmButton={`Yes, get the answer!`}
             cancelButton="Nevermind! We'll keep trying."
             onConfirm={() => {
-                this.setState({showConfirm: false, division: "noncompetitive" })
+                this.setState({showConfirm: false});
                 this._doGiveUp();
             }}
+
             onCancel={() => this.setState({showConfirm: false})}
             size="large"
           />
         );
       }
 
+    _enabled() {
+      const { loading, puzzle } = this.props;
+      const { now } = this.state;
+      if (!now || !puzzle || loading || puzzle.end) return false;
+
+      // Enable only if at least halfway through the puzzle
+      const waitUntil = moment(moment(puzzle.start) +
+                               moment.duration({minutes: puzzle.allowedTime / 2}));
+      return now.isAfter(waitUntil);
+    }
+
     render(){
+        const { puzzle } = this.props;
+        const disabled = !this._enabled();
         return (
             <div>
                 { this._confirmationModal() }
-                <Button fluid color='red' content='Get the Answer'
-                    disabled={this.state.loading} onClick={this._handleClick} />
+                <Button fluid color='red' content='Give Up'
+                        disabled={disabled} onClick={this._handleClick} />
             </div>
         );
     }
@@ -80,4 +128,4 @@ GiveUp.propTypes = {
     team: PropTypes.object.isRequired,
     puzzle: PropTypes.object.isRequired,
 };
-  
+

--- a/client/components/game/imports/PuzzleAnswerForm.jsx
+++ b/client/components/game/imports/PuzzleAnswerForm.jsx
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Image, Form, Message } from 'semantic-ui-react';
-import NCGiveUp from './NCGiveUp';
+import GiveUp from './NCGiveUp';
 
 export default class PuzzleAnswerForm extends React.Component {
   messageTimer = null;
@@ -44,10 +44,10 @@ export default class PuzzleAnswerForm extends React.Component {
 
   _giveUpButton() {
     const { team, puzzle } = this.props;
-    const show = team.division === "noncompetitive";
-    if(!show) return null;
+    // Don't give this option for "short" puzzles (e.g. Meta Puzzle)
+    if (puzzle.allowedTime < 30) return null;
 
-    return <NCGiveUp team={team} puzzle={puzzle} />
+    return <GiveUp team={team} puzzle={puzzle} />;
   }
 
   _handleSubmit(e) {

--- a/lib/collections/teams.js
+++ b/lib/collections/teams.js
@@ -11,6 +11,7 @@ import {
   cloneDeep,
   omit,
 } from 'lodash';
+import moment from 'moment';
 
 import { requireUser, requireVolunteer, NonEmptyString, requirePattern,
 	 ValidNameString, notAfterCheckIn, checkMsg, requireAdmin } from '../imports/method-helpers.js';
@@ -377,9 +378,6 @@ Meteor.methods({
     const team = Teams.findOne(teamId);
     if(!team) throw new Meteor.Error(400, `No team found with id ${teamId}`);
     const teamNameShort = getShortName(team.name);
-    if(!team.division === "noncompetitive"){
-      throw new Meteor.Error(400, "Only non-competitive teams can give up");
-    }
     if(!team.currentPuzzle) throw new Meteor.Error(400, "No active puzzle for this team");
 
     if (!Meteor.isServer) return true;
@@ -389,9 +387,13 @@ Meteor.methods({
 
     const i = findIndex(team.puzzles, (p) => p.puzzleId === puzzleId);
     const puzzle = team.puzzles[i] || {};
+    if (!moment().isAfter(moment(puzzle.start) +
+                          moment.duration({minutes: puzzle.allowedTime / 2}))) {
+      throw new Meteor.Error(400, "You can't give up yet!");
+    }
 
     const endTime = new Date();
-    const score = getPuzzleScore(team.puzzles[i], endTime, masterPuzzle, /*isNC=*/true);
+    const score = moment.duration({minutes: masterPuzzle.timeoutScore}).asSeconds();
     const answer = masterPuzzle.answer.trim().toLowerCase();
     Meteor.logger.info(`Team "${teamNameShort}" is giving up on puzzle ${puzzle.name}`);
 


### PR DESCRIPTION
Once available only to the "non-competitive" division that was trialed
one year at the Hunt, we're now opening up the "give up" ability to
all teams. The button can only be used after half of the puzzle's
allowed time, so this component has some upgrades to make it
time-aware.

# Flow:
Before halfway mark, button is not available:
![Screen Shot 2024-04-14 at 18 25 32](https://github.com/cabeese/greatpuzzlehunt/assets/12406521/595d90dc-97a4-408e-95e0-a3451ccc123f)

After halfway mark, button is available:
![Screen Shot 2024-04-14 at 18 46 11](https://github.com/cabeese/greatpuzzlehunt/assets/12406521/afebd460-3314-4cd1-b473-9ee5a07c603c)

Clicking the button gives a prompt:
![Screen Shot 2024-04-14 at 18 46 19](https://github.com/cabeese/greatpuzzlehunt/assets/12406521/3b03c4fe-f0bf-4f99-933d-d0f57e282b24)

If you follow through, the answer is revealed and the timeout score is set to the max (105 minutes). Note that the "end time" reflects the time when they gave up, but is not used for the score.
![Screen Shot 2024-04-14 at 18 49 51](https://github.com/cabeese/greatpuzzlehunt/assets/12406521/c2703939-9207-47f1-a1c6-0a30dee00340)
