### PR TITLE
Add "puzzle watcher" to move monitoring to separate process

### DIFF
--- a/.meteorignore
+++ b/.meteorignore
@@ -1,0 +1,1 @@
+workers/

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web:    .meteor/heroku_build/bin/node $NODEJS_PARAMS .meteor/heroku_build/app/main.js
+worker: node $NODEJS_PARAMS workers/puzzle-timeouts.js

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ npm start
 
 to start the server. Then navigate to `localhost:3000` to see the page.
 
+## Puzzle Watcher "Worker"
+
+The run loop that checks for timed-out puzzles can be offloaded to a
+separate process, and should be when running in production. For
+details, see the documentation in `workers/README.md`.
+
 ## Development Setup Prior to Meteor 3
 
 > NOTE: These instructions are for older versions of the project using Meteor@2.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Puzzle Hunt Game System",
   "main": "main.js",
   "scripts": {
-    "start": "meteor --settings settings-development.json || true",
+    "start": "PUZZLE_WATCHER_IN_MAIN_PROCESS=true meteor --settings settings-development.json || true",
     "test": "echo \"Error: no test specified\" && exit 1",
     "deploy": "git tag `date \"+deploy-%Y_%m_%d-%H_%M_%S\"` && git push --tags && mup deploy --config=mup-production.js --settings=settings-production.json"
   },

--- a/server/imports/puzzle-watcher.js
+++ b/server/imports/puzzle-watcher.js
@@ -1,9 +1,13 @@
 import { Meteor } from 'meteor/meteor';
 import moment from 'moment';
 import { getShortName } from '../../lib/imports/util';
+import { asBool } from '../../util/parse-env-args';
 
 import { Teams } from '../../lib/collections/teams'
 import { Puzzles } from '../../lib/collections/puzzles'
+
+const PUZZLE_WATCHER_IN_MAIN_PROCESS =
+      asBool(process.env.PUZZLE_WATCHER_IN_MAIN_PROCESS);
 
 const CHECK_INTERVAL = {
   seconds: 5,
@@ -50,9 +54,16 @@ async function timeOutPuzzles() {
 }
 
 Meteor.startup(() => {
-  // On Startup, init Interval for puzzle timeout watcher.
-  const interval = moment.duration(CHECK_INTERVAL).asMilliseconds();
-  Meteor.setInterval(async() => {
-    await timeOutPuzzles()
-  }, interval);
+  if (PUZZLE_WATCHER_IN_MAIN_PROCESS) {
+    // On Startup, init Interval for puzzle timeout watcher.
+    const interval = moment.duration(CHECK_INTERVAL).asMilliseconds();
+    Meteor.logger.warn("Puzzle Watcher logic is running in the main thread. " +
+                       "This may cause performance issues in production.");
+    Meteor.setInterval(async() => {
+      await timeOutPuzzles()
+    }, interval);
+  } else {
+    Meteor.logger.info("Puzzle Watcher logic is NOT running in the main thread. " +
+                       "This is expected if a worker process is running.");
+  }
 });

--- a/util/parse-env-args.js
+++ b/util/parse-env-args.js
@@ -1,0 +1,36 @@
+// A collection of helpers for interpreting environment variables as
+// sane types (ints, bools, etc). Intended for runtime configuration
+// flexibility.
+
+export const asInt = (arg, default_value = -1) => {
+  const as_int = parseInt(arg, 10);
+  if (String(as_int) == arg) {
+    return as_int;
+  }
+  return default_value;
+}
+
+export const asBool = (arg) => {
+  // Could be unset (false)
+  if (arg === "" || arg === null || arg === undefined) {
+    return false;
+  }
+
+  // Could be 0/1 (or any number, really - this isn't thorough)
+  const as_int = asInt(arg, -1);
+  if (as_int != -1) {
+    return !!as_int;
+  }
+
+  // Could be true/false
+  const as_lc = String(arg).toLowerCase();
+  if (as_lc === "true" || as_lc === "t") {
+    return true;
+  } else if (as_lc === "false" || as_lc === "f") {
+    return false;
+  }
+
+  // Hrm, it's something suspicious!
+  console.warn(`Failed to parse "${arg}" as a sane boolean`);
+  return false;
+}

--- a/workers/README.md
+++ b/workers/README.md
@@ -1,0 +1,77 @@
+# Motivation
+
+As originally created, the GPH site is a single Meteor server, which
+can have multiple instances running in parallel across different
+servers (Heroku "Dynos") to improve throughput handling. This works
+well for client-initiated requests such as page loading, Puzzle
+starting/stopping, team creation, and so on.
+
+However, there is one piece of functionality that does not match well
+with this type of configuration: there is a repeated process that
+happens during gameplay where all active teams are polled to determine
+if they have run out of time on a puzzle. This needs to happen
+frequently so teams don't go beyond their time, but it does not need
+to scale out in parallel in the same way web request servicing can be.
+
+Instead, the "puzzle watcher" needs only a single running instance at
+any given time. In order to achieve this, we make use of Heroku
+"worker" dynos which can be scaled manually separately from the web
+dynos. This means that the Watcher can run in its own, independent
+Unix process without affecting the event loop of every single web
+worker.
+
+# Technical Details
+
+> Note that some of this is Heroku-configuration-specific and may not
+  apply directly to other hosting services.
+
+The `Procfile` informs Heroku what resources are needed to run the
+app. By default, it includes a single line for Web dynos based on the
+"horse" buildpack. We add an additional configuration for starting and
+running a separate Node process that watches for timed-out puzzles.
+
+Note that because the Watcher is not running under the Meteor context,
+we don't have access to some of the Meteor convenience functions (like
+MongoDB collections or logging).
+
+# Running Locally
+
+You can run this app locally either with or without the separate
+watcher process. Running `npm start` like normal will start the server
+with the watcher running in the Meteor process (legacy setup).
+
+If you'd like to run with the separate watcher process, you must:
+
+* Start the server with `PUZZLE_WATCHER_IN_MAIN_PROCESS=false`
+* Start the Watcher process
+
+To start the server without the watcher process, either modify the
+flag in the `package.json` file or run
+
+```shell
+meteor --settings settings-development
+```
+
+> If the env var is unset or set to `0` or `false`, the server will
+  assume the worker is running instead.
+
+The watcher can be started in two ways:
+
+### Via Heroku CLI
+
+This method is preferred as it exercises the configuration in the
+`Procfile`. However, if you do not have the Heroku CLI installed, you
+can use the second method.
+
+```shell
+MONGO_URL="mongodb://127.0.0.1:3001/meteor" heroku local worker
+```
+
+### Via Node
+
+This option is suitable if you don't have the Heroku CLI. It should be
+functionally equivalent.
+
+```shell
+MONGO_URL="mongodb://127.0.0.1:3001/meteor" node workers/puzzle-timeouts.js
+```

--- a/workers/puzzle-timeouts.js
+++ b/workers/puzzle-timeouts.js
@@ -1,0 +1,160 @@
+const { MongoClient } = require('mongodb');
+const moment = require('moment');
+
+const MONGO_URL = process.env.MONGO_URL;
+// Number of times the RunLoop can fail before we give up.
+const ERROR_MAX = 5;
+
+const sleep = delay_ms => {
+  return new Promise((resolve) => setTimeout(resolve, delay_ms));
+}
+
+// =============================================================================
+// Database Connections
+// =============================================================================
+
+function establishClient() {
+  console.log("Establishing watcher's MongoDB connection...");
+  return new MongoClient(MONGO_URL);
+}
+
+async function getGamestate(db) {
+  return await db.collection("gamestate").findOne();
+}
+
+async function gameIsInPlay(db) {
+  const gamestate = await getGamestate(db);
+  return gamestate.gameplay;
+}
+
+async function getPuzzles(db) {
+  const all_puzzles = await db.collection("puzzles").find().toArray();
+  // Put the puzzles in a map in the form { _id: <puzzle> }
+  const puzzles = all_puzzles.reduce((acc, p) => {
+    acc[p._id] = p;
+    return acc;
+  }, {});
+  return puzzles;
+}
+
+async function getActiveTeams(db) {
+  return await db.collection("teams")
+    .find({ currentPuzzle: { $ne: null } })
+    .project({ currentPuzzle: 1, name: 1, puzzles: 1})
+    .toArray();
+}
+
+// =============================================================================
+// Game Logic
+// =============================================================================
+
+// Counter for loop iterations for (temporary?) monitoring purposes.
+let DEBUG_iter_ct = 0;
+
+async function timeOutTeams(puzzles_cached, db) {
+  const teams = await getActiveTeams(db);
+  const now = moment();
+
+  // Unless teams are actively timing out, there's little to no
+  // indication that this watcher process is active. In lieu of proper
+  // metrics and monitoring (which can hopefully be added at some
+  // point), we can add a log line every so often so we have
+  // confidence that this logic is being executed.
+  if (++DEBUG_iter_ct % (60 * 5) === 0) {
+    console.debug(`Watcher monitoring ${teams.length} active teams`);
+  }
+
+  // Note that Errors thrown in the lambda will cause the entire
+  // worker to crash and will not be handled by any of the error
+  // handling code surrounding this function. We try to catch errors
+  // where we expect they can be thrown, and simply 'return' instead.
+  teams.forEach(async team => {
+    const i = team.puzzles.findIndex((p) => (p.puzzleId === team.currentPuzzle));
+    if (i < 0) {
+      console.error(`Could not find original puzzle for team "${team.name}"` +
+                    ` with currentPuzzle=${team.currentPuzzle}`);
+      console.error(team.puzzles);
+      return;
+    }
+    const puzzle = team.puzzles[i];
+    const allowedTime = { minutes: puzzle.allowedTime };
+    const timeOutScore = moment.duration({ minutes: puzzle.timeoutScore }).asSeconds();
+    const maxTime = moment(puzzle.start).add(allowedTime);
+    const answer = puzzles_cached[puzzle.puzzleId].answer;
+
+    // Time out the given puzzle for this team.
+    if (now.isAfter(maxTime)) {
+      console.log(`Team "${team.name}" timed out on puzzle ${puzzle.name}`);
+      try {
+        await db.collection("teams").updateOne(
+          {_id: team._id},
+          {
+            $set: {
+              currentPuzzle: null,
+              [`puzzles.${i}.end`]: maxTime.toDate(),
+              [`puzzles.${i}.score`]: timeOutScore,
+              [`puzzles.${i}.answer`]: answer,
+              [`puzzles.${i}.timedOut`]: true,
+            },
+          }
+        );
+      } catch (error) {
+        console.error(`Failed to time out team "${team.name}"!`);
+        console.error(error);
+      }
+    }
+  });
+}
+
+async function runLoop(db) {
+  console.log("Puzzle Watcher gameplay loop beginning");
+  const puzzles_cached = await getPuzzles(db);
+  while (true) {
+    const teams = await getActiveTeams(db);
+    await timeOutTeams(puzzles_cached, db);
+    await sleep(1000);
+  }
+}
+
+// =============================================================================
+// Runner
+// =============================================================================
+
+async function main() {
+  console.log("Puzzle Watcher worker process starting");
+  const client = establishClient();
+  await client.connect();
+  const db = await client.db();
+
+  // Wait for the game to start. Poll every minute until it does. Once
+  // it starts, begin the run loop. The run loop can fail up to
+  // ERROR_MAX times before we give up and quit the runner entirely.
+  let error_count = 0;
+  while (error_count < ERROR_MAX) {
+    // TODO: this loop still isn't right because it doesn't properly
+    // exit the RunLoop once gameplay is turned off. This isn't super
+    // important since we can just kill the worker at that point, but
+    // it's annoying and relevant for local debugging.
+    if (await gameIsInPlay(db)) {
+      try {
+        await runLoop(db);
+        console.error("Run loop returned. This is unexpected!");
+      } catch(error) {
+        console.error(`Run loop threw an error! ${error}`);
+        error_count++;
+        await sleep(5 * 1000);
+      }
+    } else {
+      await sleep(60 * 1000);
+    }
+  }
+
+  // Close so the worker process can shut down cleanly
+  await client.close();
+}
+
+main().then(() => {
+  console.log("Puzzle Watcher completed - shutting down");
+}).catch(error => {
+  console.error("Puzzle Watcher encountered an error:", error);
+});


### PR DESCRIPTION
This PR moves the "puzzle timeout" logic to a script that can be run in a process separate from Meteor. For more details, see the `workers/README.md` file added.