### PR TITLE
Fix puzzle download for in-person teams

### DIFF
--- a/lib/collections/teams.js
+++ b/lib/collections/teams.js
@@ -571,6 +571,8 @@ Meteor.methods({
     const teamNameShort = getShortName(team.name);
     const i = findIndex(team.puzzles, (p) => p.puzzleId === puzzleId);
     const puzzle = team.puzzles[i];
+    const masterPuzzle = await Puzzles.findOneAsync(puzzle.puzzleId);
+    if (!masterPuzzle) throw new Meteor.Error("500, Unable to find master puzzle");
 
     // Make sure there are no puzzles to solve with stage lower than this one still.
     const preReqPuzzles = team.puzzles.some((p, ix) => {
@@ -584,6 +586,7 @@ Meteor.methods({
     return await Teams.updateAsync(teamId, {
       $set: {
         [`puzzles.${i}.start`]: new Date(),
+        [`puzzles.${i}.downloadURL`]: masterPuzzle.downloadURL,
         currentPuzzle: puzzleId,
       },
     });


### PR DESCRIPTION
The "Download Puzzle" button was broken for in-person teams because the download URL wasn't set when starting a puzzle via QR code.