### PR TITLE
Unload volunteer pages after starting a puzzle

### DIFF
--- a/client/components/volunteer/imports/ActivePuzzle.jsx
+++ b/client/components/volunteer/imports/ActivePuzzle.jsx
@@ -8,6 +8,60 @@ import PuzzleProgress from '../../imports/PuzzleProgress';
 export default class ActivePuzzle extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {
+      showInactivityWarning: false,
+    };
+    this.resetInactivityTimers = this.resetInactivityTimers.bind(this);
+    this.restartInactivityTimers = this.restartInactivityTimers.bind(this);
+  }
+
+  componentDidMount() {
+    this.startInactivePageTimer();
+  }
+  componentWillUnmount() {
+    this.resetInactivityTimers();
+  }
+
+  // When the component loads, begin the first clock. When this
+  // timer expires, display the note that the page is closing soon.
+  startInactivePageTimer() {
+    this.inactiveTimeoutPhase1 = Meteor.setTimeout(
+      this.inactivePageWarn.bind(this), 1000 * 60);
+  }
+
+  // The page is about to "close" due to inactivity. Give the user a
+  // chance to extend/reset the timer before this happens.
+  inactivePageWarn() {
+    this.setState({showInactivityWarning: true});
+    this.inactiveTimeoutPhase2 = Meteor.setTimeout(
+      this.goToInactivePage, 1000 * 60);
+  }
+
+  // Clear the timers tracking inactivity on this page. May be called
+  // because the user requested an extension or because the component
+  // is unloading (e.g. user navigating away or reset the team's
+  // puzzle timer, reverting back to the UnstartedPuzzle component).
+  resetInactivityTimers() {
+    if (this.inactiveTimeoutPhase1) {
+      Meteor.clearTimeout(this.inactiveTimeoutPhase1);
+    }
+    if (this.inactiveTimeoutPhase2) {
+      Meteor.clearTimeout(this.inactiveTimeoutPhase2);
+    }
+    this.setState({showInactivityWarning: false});
+  }
+
+  // Similar to the above, but start the timer again after clearing
+  // the existing timeouts (i.e. user requested extension).
+  restartInactivityTimers() {
+    this.resetInactivityTimers();
+    this.startInactivePageTimer();
+  }
+
+  // Loads a blank-ish HTML page so that this browser tab is no longer
+  // holding an open websocket connection to the server.
+  goToInactivePage() {
+    window.location.href = "/inactive.html";
   }
 
   render() {
@@ -24,7 +78,23 @@ export default class ActivePuzzle extends React.Component {
           content='Reset Timer'
           onClick={ async () => await this._resetTimer() }
         />
+        {this._inactivityMessage()}
       </Segment>
+    );
+  }
+
+  _inactivityMessage() {
+    const { showInactivityWarning } = this.state;
+    if (!showInactivityWarning) {
+      return "";
+    }
+    return (
+      <Button
+        basic fluid
+        color='yellow'
+        content='This page will close in under a minute. Click to cancel'
+        onClick={ this.restartInactivityTimers }
+      />
     );
   }
 
@@ -37,6 +107,8 @@ for team: ${team.name}?
 Are you absolutely positive?
 `
     if (!confirm(confirmMsg)) return;
+
+    this.resetInactivityTimers();
 
     try {
       await Meteor.callAsync('volunteer.team.resetPuzzle', team._id, puzzle.puzzleId);

--- a/public/inactive.html
+++ b/public/inactive.html
@@ -1,0 +1,30 @@
+<html>
+  <head>
+    <title>Great Puzzle Hunt - Inactive Page</title>
+    <link rel="icon" type="image/png" href="/img/favicon.png" />
+
+    <style>
+      body {
+          background-image: url("/img/pattern-small.png");
+      }
+      #message {
+          padding: 10px;
+          margin: 10px;
+          background-color: rgb(33, 133, 208);
+          text-align: center;
+          font-family: Roboto, sans-serif;
+          font-size: 36px;
+          color: white;
+          box-shadow: 10px 5px 5px black;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="message">
+      This page has gone idle to save resources.
+      <br /><br />
+      You may close this tab, or use your browser's Back button to return to the
+      previous page.
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Direct to a non-websocket page after some amount of time to avoid further taxing the server.

See commit messages and comments for more details