### PR TITLE
Fixes #281. Disable game selection buttons if Volunteer

### DIFF
--- a/client/components/register/imports/RegisterForm.jsx
+++ b/client/components/register/imports/RegisterForm.jsx
@@ -183,9 +183,11 @@ class RegisterForm extends Component {
 
   _form() {
     const gameModeConflict = this.state.playingTreasureHunt && this.state.gameMode === "VIRTUAL";
-    const registrationPuzzleHuntOpen = this.props.gamestate.registrationInPersonOpen ||
-          this.props.gamestate.registrationVirtualOpen;
-    const registrationTreasureHuntOpen = this.props.gamestate.registrationTreasureHuntOpen;
+    const registrationPuzzleHuntAllowed = this.state.accountType !== "VOLUNTEER" &&
+          ( this.props.gamestate.registrationInPersonOpen ||
+            this.props.gamestate.registrationVirtualOpen );
+    const registrationTreasureHuntAllowed = this.props.gamestate.registrationTreasureHuntOpen
+          && this.state.accountType !== "VOLUNTEER";
     return (
       <div>
         <Form onSubmit={ async (e) => { await this._register(e); } } style={ this._formStyle() }>
@@ -248,7 +250,7 @@ class RegisterForm extends Component {
             defaultChecked={this.state.playingPuzzleHunt}
             name='playingPuzzleHunt'
             label="Participating in the Great Puzzle Hunt"
-            disabled={!registrationPuzzleHuntOpen}
+            disabled={!registrationPuzzleHuntAllowed}
             onChange={ (e,data) => this._handleDataChange(e,data) } />
           <Form.Checkbox
             toggle
@@ -257,7 +259,7 @@ class RegisterForm extends Component {
               pointing: 'left',
             } : null}
             defaultChecked={this.state.playingTreasureHunt}
-            disabled={!registrationTreasureHuntOpen}
+            disabled={!registrationTreasureHuntAllowed}
             name='playingTreasureHunt'
             label="Participating in the Treasure Hunt"
             onChange={ (e,data) => this._handleDataChange(e,data) } />


### PR DESCRIPTION
Add an earlier visual indication that VOLUNTEER account types cannot select one of the "Playing*Hunt" options. Note that it's still possible to get the form into an invalid state by first toggling one of the checkboxes to true and then selecting VOLUNTEER, but the functional checks to prevent incorrect registration are already in place so this is just to improve registration flow for volunteers.

<img width="673" height="380" alt="gph-281-pic-1" src="https://github.com/user-attachments/assets/01ede4b2-cf9f-4a98-82f5-d591d2e43497" />
