### PR TITLE
Updates to treasure hunt play and help

### DIFF
--- a/client/components/admin/AdminTreasureHunt/imports/CheckpointEditor.js
+++ b/client/components/admin/AdminTreasureHunt/imports/CheckpointEditor.js
@@ -91,6 +91,7 @@ class CheckpointEditor extends Component {
         </Form.Group>
 
         { this._textMultilineInput("startDescription", "Description of start") }
+	{ this._textInput("startImage", "Optional URL of an image to show with start description") }
 	{ this._textMultilineInput("codewordLabel", "Label for codeword entry") }
         { this._textMultilineInput("finishDescription", "Message on finishing") }
 
@@ -109,7 +110,7 @@ class CheckpointEditor extends Component {
 
   async _save(e) {
     e.preventDefault();
-    const { name, sequence, startDescription, codewordLabel,
+    const { name, sequence, startDescription, codewordLabel, startImage,
 	    finishDescription, 
             codeword, hasCodeword } = this.state;
     const nonCharacterDigit = /[^a-zA-Z0-9]/ug
@@ -118,6 +119,7 @@ class CheckpointEditor extends Component {
       sequence: parseInt(sequence),
       startDescription: startDescription.trim(),
       codewordLabel: codewordLabel.trim(),
+      startImage: startImage.trim(),
       finishDescription: finishDescription.trim(),
       codeword: codeword.trim(),
       hasCodeword: hasCodeword

--- a/client/components/game/imports/GameStats.jsx
+++ b/client/components/game/imports/GameStats.jsx
@@ -76,10 +76,10 @@ class GameStats extends Component {
 	  <Button content='Team Treasure Hunt page' />
 	</Link>
 	<br/>
-	For the Official Treasure Hunt Map:
+	For the Official Treasure Hunt Map and Log:
 	<ul>
 	  <li> Download and read map from your mobile device, or </li>
-	  <li> Pick up a hard copy in the Math Center in Bond Hall 209/211A. </li>
+	  <li> Pick up a hard copy at puzzle stations during the Great Puzzle Hunt. </li>
 	</ul>
       </div>
     );

--- a/client/components/public/about-th.jsx
+++ b/client/components/public/about-th.jsx
@@ -87,7 +87,7 @@ class AboutTh extends Component {
                size='medium' floated='right' />
 
         <p>
-          Keep the map and compass handy, mark your finds on the map and keep a notebook to log information as you travel (see <a href="#tools">tools</a> section). <strong>You may need to enter information in a particular order at QR checkpoints</strong>, where your team will scan, sign in, and answer a question to receive information to the next clue.
+          Keep the map and compass handy, mark your finds on the map and keep a notebook to log information as you travel (see <a href="#tools">tools</a> section), or print a copy of the Treasure Hunt Log. <strong>You may need to enter information in a particular order at QR checkpoints</strong>, where your team will scan, sign in, and answer a question to receive information to the next clue.
         </p>
 
         <p>
@@ -142,7 +142,7 @@ class AboutTh extends Component {
         </p>
 
         <p>
-          Access the Official Treasure Hunt Map and Secret Starting Location  starting at 7:00 am on April 19, 2026.
+          Access the Official Treasure Hunt Map, Secret Starting Location, and Log  starting at 7:00 am on April 19, 2026.
         </p>
 
         <List bulleted>
@@ -153,10 +153,10 @@ class AboutTh extends Component {
             The Treasure Hunt is open April 19, 2026, 7:00 AM to April 20, 2026, 8:00 PM. However, Great Puzzle Hunt finishers gain early access to the Treasure Hunt on April 18, 2026. 
           </List.Item>
           <List.Item>
-            Registered Great Puzzle Hunt & Treasure Hunt Players will see a link to their team Treasure Hunt page, with the Official Treasure Hunt Map and Secret Starting Location, upon completion of the Meta-Puzzle. 
+            Registered Great Puzzle Hunt & Treasure Hunt Players will see a link to their team Treasure Hunt page, with the Official Treasure Hunt Map,  Secret Starting Location, and Log upon completion of the Meta-Puzzle. 
           </List.Item>
           <List.Item>
-            Registered Great Puzzle Hunt & Treasure Hunt Players who do not complete the MetaPuzzle can access the Official Treasure Hunt Map and Secret Starting Location starting at 7:00 am on April 19, 2026 through the Treasure Hunt link in the top bar on this web site.
+            Registered Great Puzzle Hunt & Treasure Hunt Players who do not complete the MetaPuzzle can access the Official Treasure Hunt Map, Secret Starting Location, and Log starting at 7:00 am on April 19, 2026 through the Treasure Hunt link in the top bar on this web site.
           </List.Item>
         </List>
       </div>
@@ -217,7 +217,7 @@ class AboutTh extends Component {
       <div>
         <List bulleted>
           <List.Item>
-            <strong>Official Treasure Hunt Map</strong> accessible from your team's Treasure Hunt page; you may want to print a copy
+            <strong>Official Treasure Hunt Map</strong> and <strong>Log</strong> accessible from your team's Treasure Hunt page; you may want to print a copy of each
           </List.Item>
           <List.Item>
             <strong>Secret starting location</strong> on your team's Treasure Hunt page
@@ -297,7 +297,7 @@ class AboutTh extends Component {
         </p>
 
         <p>
-          Event Starts. Registered Treasure Hunt players can access the Official Treasure Hunt Map and Secret Starting Locations.
+          Event Starts. Registered Treasure Hunt players can access the Official Treasure Hunt Map, Log, and Secret Starting Locations.
         </p>
 
         <p>

--- a/client/components/treasurehunt/imports/TreasureTeamWrapper.jsx
+++ b/client/components/treasurehunt/imports/TreasureTeamWrapper.jsx
@@ -4,7 +4,7 @@ import { withTracker } from 'meteor/react-meteor-data';
 import { sortBy} from 'lodash';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { Button, Container, Grid, Header, Label, Message } from 'semantic-ui-react';
+import { Button, Container, Grid, Header, Image, Label, Message } from 'semantic-ui-react';
 
 import { THCheckpoints } from '../../../../lib/collections/thcheckpoints.js';
 import { Teams } from '../../../../lib/collections/teams.js'
@@ -108,12 +108,8 @@ class TreasureTeamWrapper extends Component {
 			  content='Download'
 			  href={mapURL}
 		  />
-		  <br/>
-		  <ul>
-		    <li> Download and read map from your mobile device, or </li>
-		    <li> You may want to print a hard copy. </li>
-		  </ul>
 		</Container>
+		<br/>
 		<Container>
 		  Treasure Hunt Log &nbsp;
 		  <Button basic
@@ -122,7 +118,16 @@ class TreasureTeamWrapper extends Component {
 			  content='Download'
 			  href={logURL}
 		  />
+		  <br/>
+		  <ul>
+		    <li> Download and read map and log from your mobile device, or </li>
+		    <li> You may want to print a hard copy. </li>
+		  </ul>
 		</Container>
+	    <Button basic size='small' content='Clear playing'
+		    color='black'
+		    onClick={ async () => await this._clearPlaying() }
+		    />
 	      </Grid.Column>
 	    </Grid.Row>
 	  </Grid>
@@ -213,11 +218,25 @@ class TreasureTeamWrapper extends Component {
     if (ckActive != null) {
       msgActive = formatLabel(ckActive == null ? '' : ckActive.startDescription)
     }
+    console.log('ckactive: ');
+    console.log(ckActive);
+    const imgActive = this._imgActive(ckActive);
+    console.log('imgactive:');
+    console.log(imgActive);
     return (
       <div>
-	{msgCompleted} {msgActive}
+	{msgCompleted} {msgActive} {imgActive}
       </div>
     );
+  }
+
+  _imgActive(ckActive) {
+    if (ckActive != null) {
+      if (ckActive.startImage != null) {
+	return <Image src={ckActive.startImage} inline />
+      }
+    }
+    return null;
   }
 
   _oneCheckpoint(checkpoint, active) {
@@ -245,6 +264,16 @@ class TreasureTeamWrapper extends Component {
     const teamId = team._id;
     try {
       await Meteor.callAsync('team.startTreasureHunt', teamId);
+    } catch (error) {
+      alert(error.reason);
+    }
+  }
+
+  async _clearPlaying() {
+    const { team } = this.props;
+    const teamId = team._id;
+    try {
+      await Meteor.callAsync('team.clearTreasureHunt', teamId);
     } catch (error) {
       alert(error.reason);
     }

--- a/client/components/treasurehunt/imports/TreasureTeamWrapper.jsx
+++ b/client/components/treasurehunt/imports/TreasureTeamWrapper.jsx
@@ -124,10 +124,6 @@ class TreasureTeamWrapper extends Component {
 		    <li> You may want to print a hard copy. </li>
 		  </ul>
 		</Container>
-	    <Button basic size='small' content='Clear playing'
-		    color='black'
-		    onClick={ async () => await this._clearPlaying() }
-		    />
 	      </Grid.Column>
 	    </Grid.Row>
 	  </Grid>
@@ -218,11 +214,7 @@ class TreasureTeamWrapper extends Component {
     if (ckActive != null) {
       msgActive = formatLabel(ckActive == null ? '' : ckActive.startDescription)
     }
-    console.log('ckactive: ');
-    console.log(ckActive);
     const imgActive = this._imgActive(ckActive);
-    console.log('imgactive:');
-    console.log(imgActive);
     return (
       <div>
 	{msgCompleted} {msgActive} {imgActive}
@@ -264,16 +256,6 @@ class TreasureTeamWrapper extends Component {
     const teamId = team._id;
     try {
       await Meteor.callAsync('team.startTreasureHunt', teamId);
-    } catch (error) {
-      alert(error.reason);
-    }
-  }
-
-  async _clearPlaying() {
-    const { team } = this.props;
-    const teamId = team._id;
-    try {
-      await Meteor.callAsync('team.clearTreasureHunt', teamId);
     } catch (error) {
       alert(error.reason);
     }

--- a/lib/collections/teams.js
+++ b/lib/collections/teams.js
@@ -603,12 +603,12 @@ Meteor.methods({
   async 'team.treasure.answer'(checkpointId, answer) {
     check(checkpointId, String);
     check(answer, String);
+
     requireUser();
     const user = await Meteor.userAsync();
     if (!user.teamId) throw new Meteor.Error(400, 'You must be on a team to play the treasure hunt!');
 
     if (!Meteor.isServer) return true;
-    Meteor.logger.info(`Treasure answer, checkpoint ${checkpointId} answer ${answer}`);
 
     const team = await Teams.findOneAsync(user.teamId);
     if (!team) {
@@ -633,7 +633,7 @@ Meteor.methods({
     const expected = checkpoint.codeword.replace(nonCharacterDigit, '').toLowerCase();
     const expectedSorted = expected.split('').sort().join();
 
-    if (checkpoint.hasCodeword || (cleanAnswerSorted === expectedSorted)) {
+    if (!checkpoint.hasCodeword || (cleanAnswerSorted === expectedSorted)) {
       Meteor.logger.info(`Team "${teamNameShort}" completed treasure hunt checkpoint "${checkpointId}"`);
 
       // update the team info

--- a/lib/collections/thcheckpoints.js
+++ b/lib/collections/thcheckpoints.js
@@ -28,6 +28,7 @@ Meteor.methods({
       name: String,
       sequence: Number,
       startDescription: String,
+      startImage: String,
       codewordLabel: String,
       finishDescription: String,
       codeword: String,


### PR DESCRIPTION
Addresses four issues:

1. adding a PNG file to the start message for some checkpoints
2. Add mention of log to TH FAQ
3. Change instructions on completing metapuzzle to say one can get map/log at puzzle stations
4. Fix validation of checkpoint codeword